### PR TITLE
#14: Automatically attempt to d/l dependencies from maven when building

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -1,7 +1,11 @@
 [alias]
+  core-component = //core/component-test:test
   core-server = //core/server:queue-triage-core-server
   start-core = //core/server:start
   web  = //web:queue-triage-web
+
+[download]
+  in_build = True
 
 [java]
   src_roots = src


### PR DESCRIPTION
As per Issue #14 - this change enables dependencies to be downloaded automatically from the defined maven repo.