### PR TITLE
Secure the Slack/Travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,9 @@ addons:
     - git
 
 notifications:
-    slack: dwp-queue-triage:tZldFanXMyzLxAlLjMZQeWY1
+  slack:
+    rooms:
+      - secure: hrtu4XHLH5cRM+EUEiq5P6nRWqohnaYn3oA9IxIb9IOxffxrU2el2bHlm0fG7jOnARhobmrpDvXBXqs5HX7MRMhQ6M6FpMc0sgVedoc4CMS7t27vm9OSK+1MY6T5kzO/jMlKK7Bkq/0e/rdf7vlXJYM8JLeeTnCte179yccB/Rey4oJEAnzLqd0B6WV0rwdC3i8iZQNCV/6hkG1p3V9tPd8OCRvbRgX5KchIY2Fo0JQShKaIta3ESUzG/J4M8asrrNQYYoqiP6vV/VDIRtC3ok5uGrP7PlICB3GZpJvYPSaXmafVJr5ICD6cQkUwjC6O9tV9fTjzjVU88coiWLFtp+WuTQ51wVcjDQzjLDfAq7BOeBx5z/lNs9JakEIapUaf0YghpiRtca1AR4YvEwU7lKu+LHZLdVWj1NSGLcLxnl+3+ZW8Cjl5BgmQO03nohzJWqjs2HE1U2zAG11BwWbHN66ueTY5Zm0Vq2Z8r2OVUtHYsoMuYchYq8URWy5bDTMwb3exzUgjD6QXrR1zS3h3jfZTq3OzwZDfzhmtL7YRPpUmQcxJAm9h+zcQUOUqe4xtoh6wc+rRT7txuSo7ROV72GLO4jaaQQj/GcqMuvm5miLsgRBJuFgu2VbPB0cKFJcYoX4jEg6yN7fk3rJtJrC2aeRAVJyRWHBJ7jhZTiq42FI=
     
 before_script:
   # Install Buck


### PR DESCRIPTION
Changed the travis/slack integration to only publish builds on the main repo (i.e. ignore forks).