### PR TITLE
Issue 23 resend failed message

### DIFF
--- a/core/client/src/main/java/uk/gov/dwp/queue/triage/core/client/resend/ResendFailedMessageClient.java
+++ b/core/client/src/main/java/uk/gov/dwp/queue/triage/core/client/resend/ResendFailedMessageClient.java
@@ -1,0 +1,19 @@
+package uk.gov.dwp.queue.triage.core.client.resend;
+
+import uk.gov.dwp.queue.triage.id.FailedMessageId;
+
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+@Path("/resend")
+@Produces(APPLICATION_JSON)
+public interface ResendFailedMessageClient {
+
+    @PUT
+    @Path("/${failedMessageId}")
+    void resendFailedMessage(@PathParam("failedMessageId") FailedMessageId failedMessageId);
+}

--- a/core/component-test/src/main/java/uk/gov/dwp/queue/triage/core/configuration/CoreClientConfiguration.java
+++ b/core/component-test/src/main/java/uk/gov/dwp/queue/triage/core/configuration/CoreClientConfiguration.java
@@ -4,6 +4,9 @@ import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import uk.gov.dwp.queue.triage.core.client.CreateFailedMessageClient;
+import uk.gov.dwp.queue.triage.core.client.resend.ResendFailedMessageClient;
+
+import java.util.Collections;
 
 @Configuration
 public class CoreClientConfiguration {
@@ -15,6 +18,14 @@ public class CoreClientConfiguration {
                 failedMessageRequest,
                 String.class
         );
+    }
 
+    @Bean
+    public ResendFailedMessageClient resendFailedMessageClient(TestRestTemplate testRestTemplate) {
+        return failedMessageId -> testRestTemplate.put(
+                "/core/resend/${failedMessageId}",
+                null,
+                Collections.singletonMap("failedMessageId", failedMessageId)
+        );
     }
 }

--- a/core/component-test/src/main/java/uk/gov/dwp/queue/triage/core/resend/ResendFailedMessageWhenStage.java
+++ b/core/component-test/src/main/java/uk/gov/dwp/queue/triage/core/resend/ResendFailedMessageWhenStage.java
@@ -1,0 +1,19 @@
+package uk.gov.dwp.queue.triage.core.resend;
+
+import com.tngtech.jgiven.Stage;
+import com.tngtech.jgiven.integration.spring.JGivenStage;
+import org.springframework.beans.factory.annotation.Autowired;
+import uk.gov.dwp.queue.triage.core.client.resend.ResendFailedMessageClient;
+import uk.gov.dwp.queue.triage.id.FailedMessageId;
+
+@JGivenStage
+public class ResendFailedMessageWhenStage extends Stage<ResendFailedMessageWhenStage> {
+
+    @Autowired
+    private ResendFailedMessageClient resendFailedMessageClient;
+
+    public ResendFailedMessageWhenStage aFailedMessageWithId$IsResent(FailedMessageId failedMessageId) {
+        resendFailedMessageClient.resendFailedMessage(failedMessageId);
+        return this;
+    }
+}

--- a/core/component-test/src/test/java/uk/gov/dwp/queue/triage/core/resend/ResendFailedMessageComponentTest.java
+++ b/core/component-test/src/test/java/uk/gov/dwp/queue/triage/core/resend/ResendFailedMessageComponentTest.java
@@ -1,0 +1,37 @@
+package uk.gov.dwp.queue.triage.core.resend;
+
+import com.tngtech.jgiven.annotation.ScenarioStage;
+import org.junit.Test;
+import uk.gov.dwp.queue.triage.core.BaseCoreComponentTest;
+import uk.gov.dwp.queue.triage.core.FailedMessageResourceStage;
+import uk.gov.dwp.queue.triage.core.JmsStage;
+import uk.gov.dwp.queue.triage.id.FailedMessageId;
+
+import static uk.gov.dwp.queue.triage.core.client.CreateFailedMessageRequest.newCreateFailedMessageRequest;
+import static uk.gov.dwp.queue.triage.core.client.FailedMessageStatus.RESENDING;
+import static uk.gov.dwp.queue.triage.core.domain.FailedMessageResponseMatcher.aFailedMessage;
+import static uk.gov.dwp.queue.triage.id.FailedMessageId.newFailedMessageId;
+
+public class ResendFailedMessageComponentTest extends BaseCoreComponentTest<JmsStage> {
+
+    @ScenarioStage
+    private FailedMessageResourceStage failedMessageResourceStage;
+    @ScenarioStage
+    private ResendFailedMessageWhenStage resendFailedMessageWhenStage;
+
+    @Test
+    public void name() throws Exception {
+        FailedMessageId failedMessageId = newFailedMessageId();
+
+        failedMessageResourceStage.given().aFailedMessage(newCreateFailedMessageRequest()
+                .withFailedMessageId(failedMessageId)
+                .withBrokerName("internal")
+                .withDestinationName("some-queue")
+        ).exists();
+
+        resendFailedMessageWhenStage.when().aFailedMessageWithId$IsResent(failedMessageId);
+        failedMessageResourceStage.and().aMessageWithId$IsSelected(failedMessageId);
+
+        failedMessageResourceStage.thenTheFailedMessageReturned(aFailedMessage().withStatus(RESENDING));
+    }
+}

--- a/core/dao-mongo/src/main/java/uk/gov/dwp/queue/triage/core/dao/mongo/FailedMessageConverter.java
+++ b/core/dao-mongo/src/main/java/uk/gov/dwp/queue/triage/core/dao/mongo/FailedMessageConverter.java
@@ -10,6 +10,7 @@ import uk.gov.dwp.queue.triage.id.FailedMessageId;
 
 import java.time.Instant;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import static uk.gov.dwp.queue.triage.core.domain.FailedMessageBuilder.newFailedMessage;
@@ -48,8 +49,14 @@ public class FailedMessageConverter implements DBObjectWithIdConverter<FailedMes
                 .withSentDateTime(getSentDateTime(basicDBObject))
                 .withFailedDateTime(getFailedDateTime(basicDBObject))
                 .withContent(getContent(basicDBObject))
+                .withFailedMessageStatus(getFailedMessageStatus(basicDBObject))
                 .withProperties(propertiesMongoMapper.convertToObject(basicDBObject.getString(PROPERTIES)))
                 .build();
+    }
+
+    public FailedMessageStatus getFailedMessageStatus(BasicDBObject basicDBObject) {
+        List statusHistory = (List)basicDBObject.get(STATUS_HISTORY);
+        return failedMessageStatusDBObjectMapper.convertToObject((BasicDBObject)statusHistory.get(0));
     }
 
     public FailedMessageId getFailedMessageId(BasicDBObject basicDBObject) {

--- a/core/dao-mongo/src/test/java/uk/gov/dwp/queue/triage/core/dao/mongo/FailedMessageConverterTest.java
+++ b/core/dao-mongo/src/test/java/uk/gov/dwp/queue/triage/core/dao/mongo/FailedMessageConverterTest.java
@@ -34,7 +34,7 @@ import static uk.gov.dwp.queue.triage.core.dao.mongo.FailedMessageConverter.DEST
 import static uk.gov.dwp.queue.triage.core.dao.mongo.FailedMessageConverter.PROPERTIES;
 import static uk.gov.dwp.queue.triage.core.domain.DestinationMatcher.aDestination;
 import static uk.gov.dwp.queue.triage.core.domain.FailedMessageMatcher.aFailedMessage;
-import static uk.gov.dwp.queue.triage.core.domain.FailedMessageStatus.Status.FAILED;
+import static uk.gov.dwp.queue.triage.core.domain.FailedMessageStatus.Status.SENT;
 import static uk.gov.dwp.queue.triage.core.domain.FailedMessageStatus.failedMessageStatus;
 import static uk.gov.dwp.queue.triage.id.FailedMessageId.newFailedMessageId;
 
@@ -50,7 +50,7 @@ public class FailedMessageConverterTest {
     }};
     private static final Destination SOME_DESTINATION = new Destination("broker", of("queue.name"));
     private static final BasicDBObject DESTINATION_DB_OBJECT = new BasicDBObject();
-    private static final FailedMessageStatus SOME_STATUS = failedMessageStatus(FAILED);
+    private static final FailedMessageStatus SOME_STATUS = failedMessageStatus(SENT);
     private static final BasicDBObject STATUS_DB_OBJECT = new BasicDBObject();
     private static final Instant SENT_AT = Instant.now().minus(5, ChronoUnit.MINUTES);
     private static final Instant FAILED_AT = Instant.now();
@@ -110,7 +110,7 @@ public class FailedMessageConverterTest {
                 .withSentAt(SENT_AT)
                 .withFailedAt(FAILED_AT)
                 .withProperties(equalTo(SOME_PROPERTIES))
-                .withFailedMessageStatus(FailedMessageStatusMatcher.equalTo(FAILED).withUpdatedDateTime(notNullValue(Instant.class)))
+                .withFailedMessageStatus(FailedMessageStatusMatcher.equalTo(SENT).withUpdatedDateTime(notNullValue(Instant.class)))
         ));
     }
 

--- a/core/search/BUCK
+++ b/core/search/BUCK
@@ -4,6 +4,7 @@ java_library(
     deps =[
         "//common/id:queue-triage-common-id",
         '//core/client:queue-triage-core-client',
+        '//core/domain:queue-triage-core-domain',
     ],
     visibility = [
         "//core/server:queue-triage-core-server",

--- a/core/search/src/main/java/uk/gov/dwp/queue/triage/core/search/FailedMessageSearchService.java
+++ b/core/search/src/main/java/uk/gov/dwp/queue/triage/core/search/FailedMessageSearchService.java
@@ -1,11 +1,11 @@
 package uk.gov.dwp.queue.triage.core.search;
 
 import uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageRequest;
-import uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageResponse;
+import uk.gov.dwp.queue.triage.core.domain.FailedMessage;
 
 import java.util.Collection;
 
 public interface FailedMessageSearchService {
 
-    Collection<SearchFailedMessageResponse> search(SearchFailedMessageRequest request);
+    Collection<FailedMessage> search(SearchFailedMessageRequest request);
 }

--- a/core/search/src/main/java/uk/gov/dwp/queue/triage/core/search/SearchFailedMessageResponseAdapter.java
+++ b/core/search/src/main/java/uk/gov/dwp/queue/triage/core/search/SearchFailedMessageResponseAdapter.java
@@ -1,0 +1,20 @@
+package uk.gov.dwp.queue.triage.core.search;
+
+import uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageResponse;
+import uk.gov.dwp.queue.triage.core.domain.FailedMessage;
+
+import static uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageResponse.newSearchFailedMessageResponse;
+
+public class SearchFailedMessageResponseAdapter {
+
+    public SearchFailedMessageResponse toResponse(FailedMessage failedMessage) {
+        return newSearchFailedMessageResponse()
+                .withBroker(failedMessage.getDestination().getBrokerName())
+                .withContent(failedMessage.getContent())
+                .withDestination(failedMessage.getDestination().getName())
+                .withFailedDateTime(failedMessage.getFailedAt())
+                .withFailedMessageId(failedMessage.getFailedMessageId())
+                .withSentDateTime(failedMessage.getSentAt())
+                .build();
+    }
+}

--- a/core/search/src/main/java/uk/gov/dwp/queue/triage/core/search/mongo/MongoFailedMessageSearchService.java
+++ b/core/search/src/main/java/uk/gov/dwp/queue/triage/core/search/mongo/MongoFailedMessageSearchService.java
@@ -1,11 +1,11 @@
 package uk.gov.dwp.queue.triage.core.search.mongo;
 
-import com.mongodb.BasicDBObject;
 import com.mongodb.DBCollection;
 import com.mongodb.DBCursor;
 import com.mongodb.DBObject;
 import uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageRequest;
-import uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageResponse;
+import uk.gov.dwp.queue.triage.core.dao.mongo.FailedMessageConverter;
+import uk.gov.dwp.queue.triage.core.domain.FailedMessage;
 import uk.gov.dwp.queue.triage.core.search.FailedMessageSearchService;
 
 import java.util.ArrayList;
@@ -16,23 +16,25 @@ public class MongoFailedMessageSearchService implements FailedMessageSearchServi
 
     private final DBCollection dbCollection;
     private final MongoSearchRequestAdapter mongoSearchRequestAdapter;
-    private final MongoSearchResponseAdapter mongoSearchResponseAdapter;
+    private final FailedMessageConverter failedMessageConverter;
 
     public MongoFailedMessageSearchService(DBCollection dbCollection,
                                            MongoSearchRequestAdapter mongoSearchRequestAdapter,
-                                           MongoSearchResponseAdapter mongoSearchResponseAdapter) {
+                                           FailedMessageConverter failedMessageConverter) {
         this.dbCollection = dbCollection;
         this.mongoSearchRequestAdapter = mongoSearchRequestAdapter;
-        this.mongoSearchResponseAdapter = mongoSearchResponseAdapter;
+        this.failedMessageConverter = failedMessageConverter;
     }
 
     @Override
-    public Collection<SearchFailedMessageResponse> search(SearchFailedMessageRequest request) {
+    public Collection<FailedMessage> search(SearchFailedMessageRequest request) {
+        // TODO: Consider adding FailedMessageConverter#convertToObjects(DBCursor dbCursor, Class<T extends Collection> collection)
         DBCursor dbCursor = dbCollection.find(mongoSearchRequestAdapter.toQuery(request));
-        List<SearchFailedMessageResponse> responses = new ArrayList<>();
+        List<FailedMessage> responses = new ArrayList<>();
         for (DBObject dbObject : dbCursor) {
-            responses.add(mongoSearchResponseAdapter.toResponse((BasicDBObject)dbObject));
+            responses.add(failedMessageConverter.convertToObject(dbObject));
         }
+        dbCursor.close();
         return responses;
     }
 }

--- a/core/search/src/main/java/uk/gov/dwp/queue/triage/core/search/mongo/spring/MongoSearchConfiguration.java
+++ b/core/search/src/main/java/uk/gov/dwp/queue/triage/core/search/mongo/spring/MongoSearchConfiguration.java
@@ -10,7 +10,6 @@ import uk.gov.dwp.queue.triage.core.dao.mongo.configuration.MongoDaoProperties;
 import uk.gov.dwp.queue.triage.core.search.FailedMessageSearchService;
 import uk.gov.dwp.queue.triage.core.search.mongo.MongoFailedMessageSearchService;
 import uk.gov.dwp.queue.triage.core.search.mongo.MongoSearchRequestAdapter;
-import uk.gov.dwp.queue.triage.core.search.mongo.MongoSearchResponseAdapter;
 
 @Configuration
 @Import(MongoDaoConfig.class)
@@ -23,7 +22,7 @@ public class MongoSearchConfiguration {
         return new MongoFailedMessageSearchService(
                 mongoClient.getDB(mongoDaoProperties.getDbName()).getCollection(mongoDaoProperties.getFailedMessage().getName()),
                 new MongoSearchRequestAdapter(),
-                new MongoSearchResponseAdapter(failedMessageConverter)
+                failedMessageConverter
         );
     }
 }

--- a/core/search/src/test/java/uk/gov/dwp/queue/triage/core/search/mongo/MongoFailedMessageSearchServiceTest.java
+++ b/core/search/src/test/java/uk/gov/dwp/queue/triage/core/search/mongo/MongoFailedMessageSearchServiceTest.java
@@ -4,13 +4,15 @@ import com.mongodb.BasicDBObject;
 import com.mongodb.DBCollection;
 import com.mongodb.DBCursor;
 import com.mongodb.DBObject;
+import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 import uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageRequest;
-import uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageResponse;
+import uk.gov.dwp.queue.triage.core.dao.mongo.FailedMessageConverter;
+import uk.gov.dwp.queue.triage.core.domain.FailedMessage;
 
 import java.util.Arrays;
 
@@ -19,15 +21,17 @@ import static org.hamcrest.Matchers.contains;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
 public class MongoFailedMessageSearchServiceTest {
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
 
     @Mock
     private DBCollection mongoCollection;
     @Mock
     private MongoSearchRequestAdapter mongoSearchRequestAdapter;
     @Mock
-    private MongoSearchResponseAdapter mongoSearchResponseAdapter;
+    private FailedMessageConverter failedMessageConverter;
     @Mock
     private SearchFailedMessageRequest request;
     @Mock
@@ -37,7 +41,7 @@ public class MongoFailedMessageSearchServiceTest {
     @Mock
     private BasicDBObject dbObject;
     @Mock
-    private SearchFailedMessageResponse response;
+    private FailedMessage failedMessage;
 
     @InjectMocks
     private MongoFailedMessageSearchService underTest;
@@ -47,9 +51,9 @@ public class MongoFailedMessageSearchServiceTest {
         when(mongoSearchRequestAdapter.toQuery(request)).thenReturn(query);
         when(mongoCollection.find(query)).thenReturn(dbCursor);
         when(dbCursor.iterator()).thenReturn(Arrays.asList((DBObject)dbObject).iterator());
-        when(mongoSearchResponseAdapter.toResponse(dbObject)).thenReturn(response);
+        when(failedMessageConverter.convertToObject(dbObject)).thenReturn(failedMessage);
 
-        assertThat(underTest.search(request), contains(response));
+        assertThat(underTest.search(request), contains(failedMessage));
 
         verify(mongoSearchRequestAdapter).toQuery(request);
         verify(mongoCollection).find(query);

--- a/core/server/BUCK
+++ b/core/server/BUCK
@@ -62,6 +62,7 @@ java_test(
         '//core/domain-test-support:queue-triage-core-domain-test-support',
         '//core/search:queue-triage-core-search',
         '//core/server:queue-triage-core-server',
+        '//core/service:queue-triage-core-service',
         '//lib:commons-lang3',
         '//lib/javax:javax-servlet-api',
         '//lib/javax:javax-ws-rs-api',

--- a/core/server/src/main/java/uk/gov/dwp/queue/triage/core/QueueTriageCoreApplication.java
+++ b/core/server/src/main/java/uk/gov/dwp/queue/triage/core/QueueTriageCoreApplication.java
@@ -5,6 +5,7 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jms.activemq.ActiveMQAutoConfiguration;
 import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.SecurityAutoConfiguration;
 import org.springframework.context.annotation.Import;
 import uk.gov.dwp.migration.mongo.demo.cxf.configuration.CxfBusConfiguration;
 
@@ -12,7 +13,13 @@ import uk.gov.dwp.migration.mongo.demo.cxf.configuration.CxfBusConfiguration;
 @Import({
         CxfBusConfiguration.class
 })
-@EnableAutoConfiguration(exclude = {MongoAutoConfiguration.class, ActiveMQAutoConfiguration.class})
+@EnableAutoConfiguration(
+        exclude = {
+                MongoAutoConfiguration.class,
+                ActiveMQAutoConfiguration.class,
+                SecurityAutoConfiguration.class,
+        }
+)
 public class QueueTriageCoreApplication {
 
     public static void main(String[] args) {

--- a/core/server/src/main/java/uk/gov/dwp/queue/triage/core/configuration/FailedMessageResourceConfiguration.java
+++ b/core/server/src/main/java/uk/gov/dwp/queue/triage/core/configuration/FailedMessageResourceConfiguration.java
@@ -9,11 +9,13 @@ import uk.gov.dwp.queue.triage.core.dao.FailedMessageDao;
 import uk.gov.dwp.queue.triage.core.dao.mongo.configuration.MongoDaoConfig;
 import uk.gov.dwp.queue.triage.core.resource.create.CreateFailedMessageResource;
 import uk.gov.dwp.queue.triage.core.resource.create.FailedMessageFactory;
+import uk.gov.dwp.queue.triage.core.resource.resend.ResendFailedMessageResource;
 import uk.gov.dwp.queue.triage.core.resource.search.FailedMessageResponseFactory;
 import uk.gov.dwp.queue.triage.core.resource.search.FailedMessageSearchResource;
 import uk.gov.dwp.queue.triage.core.resource.search.FailedMessageStatusAdapter;
 import uk.gov.dwp.queue.triage.core.search.FailedMessageSearchService;
 import uk.gov.dwp.queue.triage.core.search.SearchFailedMessageResponseAdapter;
+import uk.gov.dwp.queue.triage.core.service.FailedMessageService;
 
 @Configuration
 @Import({
@@ -37,6 +39,14 @@ public class FailedMessageResourceConfiguration {
                 new FailedMessageResponseFactory(new FailedMessageStatusAdapter()),
                 failedMessageSearchService,
                 new SearchFailedMessageResponseAdapter()
+        ));
+    }
+
+    @Bean
+    public ResendFailedMessageResource resendFailedMessageResource(ResourceRegistry resourceRegistry,
+                                                                   FailedMessageService failedMessageService) {
+        return resourceRegistry.add(new ResendFailedMessageResource(
+                failedMessageService
         ));
     }
 }

--- a/core/server/src/main/java/uk/gov/dwp/queue/triage/core/configuration/FailedMessageResourceConfiguration.java
+++ b/core/server/src/main/java/uk/gov/dwp/queue/triage/core/configuration/FailedMessageResourceConfiguration.java
@@ -13,6 +13,7 @@ import uk.gov.dwp.queue.triage.core.resource.search.FailedMessageResponseFactory
 import uk.gov.dwp.queue.triage.core.resource.search.FailedMessageSearchResource;
 import uk.gov.dwp.queue.triage.core.resource.search.FailedMessageStatusAdapter;
 import uk.gov.dwp.queue.triage.core.search.FailedMessageSearchService;
+import uk.gov.dwp.queue.triage.core.search.SearchFailedMessageResponseAdapter;
 
 @Configuration
 @Import({
@@ -22,7 +23,8 @@ import uk.gov.dwp.queue.triage.core.search.FailedMessageSearchService;
 public class FailedMessageResourceConfiguration {
 
     @Bean
-    public CreateFailedMessageResource createFailedMessageResource(ResourceRegistry resourceRegistry, FailedMessageDao failedMessageDao) {
+    public CreateFailedMessageResource createFailedMessageResource(ResourceRegistry resourceRegistry,
+                                                                   FailedMessageDao failedMessageDao) {
         return resourceRegistry.add(new CreateFailedMessageResource(new FailedMessageFactory(), failedMessageDao));
     }
 
@@ -33,7 +35,8 @@ public class FailedMessageResourceConfiguration {
         return resourceRegistry.add(new FailedMessageSearchResource(
                 failedMessageDao,
                 new FailedMessageResponseFactory(new FailedMessageStatusAdapter()),
-                failedMessageSearchService)
-        );
+                failedMessageSearchService,
+                new SearchFailedMessageResponseAdapter()
+        ));
     }
 }

--- a/core/server/src/main/java/uk/gov/dwp/queue/triage/core/resource/resend/ResendFailedMessageResource.java
+++ b/core/server/src/main/java/uk/gov/dwp/queue/triage/core/resource/resend/ResendFailedMessageResource.java
@@ -1,0 +1,21 @@
+package uk.gov.dwp.queue.triage.core.resource.resend;
+
+import uk.gov.dwp.queue.triage.core.client.resend.ResendFailedMessageClient;
+import uk.gov.dwp.queue.triage.core.service.FailedMessageService;
+import uk.gov.dwp.queue.triage.id.FailedMessageId;
+
+import static uk.gov.dwp.queue.triage.core.domain.FailedMessageStatus.Status.RESEND;
+
+public class ResendFailedMessageResource implements ResendFailedMessageClient {
+
+    private final FailedMessageService failedMessageService;
+
+    public ResendFailedMessageResource(FailedMessageService failedMessageService) {
+        this.failedMessageService = failedMessageService;
+    }
+
+    @Override
+    public void resendFailedMessage(FailedMessageId failedMessageId) {
+        failedMessageService.updateStatus(failedMessageId, RESEND);
+    }
+}

--- a/core/server/src/main/java/uk/gov/dwp/queue/triage/core/resource/search/FailedMessageSearchResource.java
+++ b/core/server/src/main/java/uk/gov/dwp/queue/triage/core/resource/search/FailedMessageSearchResource.java
@@ -7,11 +7,13 @@ import uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageResponse;
 import uk.gov.dwp.queue.triage.core.dao.FailedMessageDao;
 import uk.gov.dwp.queue.triage.core.domain.FailedMessage;
 import uk.gov.dwp.queue.triage.core.search.FailedMessageSearchService;
+import uk.gov.dwp.queue.triage.core.search.SearchFailedMessageResponseAdapter;
 import uk.gov.dwp.queue.triage.id.FailedMessageId;
 
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.NotFoundException;
 import java.util.Collection;
+import java.util.stream.Collectors;
 
 import static java.lang.String.format;
 
@@ -20,13 +22,16 @@ public class FailedMessageSearchResource implements SearchFailedMessageClient {
     private final FailedMessageDao failedMessageDao;
     private final FailedMessageResponseFactory failedMessageResponseFactory;
     private final FailedMessageSearchService failedMessageSearchService;
+    private final SearchFailedMessageResponseAdapter searchFailedMessageResponseAdapter;
 
     public FailedMessageSearchResource(FailedMessageDao failedMessageDao,
                                        FailedMessageResponseFactory failedMessageResponseFactory,
-                                       FailedMessageSearchService failedMessageSearchService) {
+                                       FailedMessageSearchService failedMessageSearchService,
+                                       SearchFailedMessageResponseAdapter searchFailedMessageResponseAdapter) {
         this.failedMessageDao = failedMessageDao;
         this.failedMessageResponseFactory = failedMessageResponseFactory;
         this.failedMessageSearchService = failedMessageSearchService;
+        this.searchFailedMessageResponseAdapter = searchFailedMessageResponseAdapter;
     }
 
     @Override
@@ -44,6 +49,9 @@ public class FailedMessageSearchResource implements SearchFailedMessageClient {
         if (request.getBroker() == null) {
             throw new BadRequestException("broker cannot be null");
         }
-        return failedMessageSearchService.search(request);
+        return failedMessageSearchService.search(request)
+                .stream()
+                .map(searchFailedMessageResponseAdapter::toResponse)
+                .collect(Collectors.toList());
     }
 }

--- a/core/server/src/test/java/uk/gov/dwp/queue/triage/core/resource/resend/ResendFailedMessageResourceTest.java
+++ b/core/server/src/test/java/uk/gov/dwp/queue/triage/core/resource/resend/ResendFailedMessageResourceTest.java
@@ -1,0 +1,24 @@
+package uk.gov.dwp.queue.triage.core.resource.resend;
+
+import org.junit.Test;
+import uk.gov.dwp.queue.triage.core.service.FailedMessageService;
+import uk.gov.dwp.queue.triage.id.FailedMessageId;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static uk.gov.dwp.queue.triage.core.domain.FailedMessageStatus.Status.RESEND;
+
+public class ResendFailedMessageResourceTest {
+
+    private static final FailedMessageId FAILED_MESSAGE_ID = FailedMessageId.newFailedMessageId();
+
+    private final FailedMessageService failedMessageService = mock(FailedMessageService.class);
+    private final ResendFailedMessageResource underTest = new ResendFailedMessageResource(failedMessageService);
+
+    @Test
+    public void successfullyMarkAMessageForResending() throws Exception {
+        underTest.resendFailedMessage(FAILED_MESSAGE_ID);
+
+        verify(failedMessageService).updateStatus(FAILED_MESSAGE_ID, RESEND);
+    }
+}


### PR DESCRIPTION
As per the commit messages:
- Refactored the `FailedMessageSearchService` to return `FailedMessage` (this used to return `SearchFailedMessageResponse` - which is part of the client-side API), as a future enhancement we could pass in an adapter to search function and return different objects.
- Messages can now be marked for Resending via a REST endpoint (next step is to add the ability to actually resend).