### PR TITLE
Improve mongo connection options

### DIFF
--- a/core/dao-mongo-test-support/src/main/resources/mongo-dao-test.properties
+++ b/core/dao-mongo-test-support/src/main/resources/mongo-dao-test.properties
@@ -1,5 +1,5 @@
-dao.mongo.host=localhost
-dao.mongo.port=27017
+dao.mongo.serverAddresses[0].host=localhost
+dao.mongo.serverAddresses[0].port=27017
 dao.mongo.dbName=queue-triage
 dao.mongo.options.ssl.enabled=false
 dao.mongo.options.ssl.invalidHostnameAllowed=false

--- a/core/dao-mongo/BUCK
+++ b/core/dao-mongo/BUCK
@@ -21,6 +21,14 @@ java_library(
     ]
 )
 
+java_library(
+    name = "test-resources",
+    resources = glob([
+        "src/test/resources/*.yml"
+    ]),
+    resources_root = "src/test/resources",
+)
+
 java_test(
     name = 'test',
     srcs = glob([ 'src/test/java/**/*Test.java']),
@@ -28,11 +36,13 @@ java_test(
         "//common/id:queue-triage-common-id",
         '//core/dao:queue-triage-core-dao',
         '//core/dao-mongo:queue-triage-core-dao-mongo',
+        '//core/dao-mongo:test-resources',
         '//core/dao-mongo-test-support:queue-triage-core-dao-mongo-test-support',
         '//core/domain:queue-triage-core-domain',
         '//core/domain-test-support:queue-triage-core-domain-test-support',
         '//lib:commons-logging',
         '//lib:guava',
+        '//lib:snakeyaml',
         '//lib/hibernate-validator:hibernate-validator',
         '//lib/javax:javax-ws-rs-api',
         '//lib/mongo:mongodb-driver',
@@ -41,6 +51,4 @@ java_test(
         '//lib/spring:spring-test',
         '//lib/test:common',
     ],
-    visibility = [
-    ]
 )

--- a/core/dao-mongo/src/main/java/uk/gov/dwp/queue/triage/core/dao/mongo/configuration/MongoDaoProperties.java
+++ b/core/dao-mongo/src/main/java/uk/gov/dwp/queue/triage/core/dao/mongo/configuration/MongoDaoProperties.java
@@ -1,6 +1,6 @@
 package uk.gov.dwp.queue.triage.core.dao.mongo.configuration;
 
-import com.mongodb.ServerAddress;
+import com.mongodb.MongoClientOptions;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
@@ -51,9 +51,18 @@ public class MongoDaoProperties {
         this.options = options;
     }
 
+    public MongoClientOptions mongoClientOptions() {
+        return new MongoClientOptions.Builder()
+                .sslEnabled(options.ssl.enabled)
+                .sslInvalidHostNameAllowed(options.ssl.invalidHostnameAllowed)
+                .build();
+    }
+
     public static class Collection {
 
         private String name = "failedMessage";
+        private Optional<String> username = Optional.empty();
+        private Optional<String> password = Optional.empty();
 
         public String getName() {
             return name;
@@ -62,6 +71,22 @@ public class MongoDaoProperties {
         public void setName(String name) {
             this.name = name;
         }
+
+        public Optional<String> getUsername() {
+            return username;
+        }
+
+        public void setUsername(Optional<String> username) {
+            this.username = username;
+        }
+
+        public Optional<String> getPassword() {
+            return password;
+        }
+
+        public void setPassword(Optional<String> password) {
+            this.password = password;
+        }
     }
 
     public static class MongoServerAddress {
@@ -69,7 +94,7 @@ public class MongoDaoProperties {
         private Integer port;
 
         public String getHost() {
-            return ofNullable(host).orElse(ServerAddress.defaultHost());
+            return host;
         }
 
         public void setHost(String host) {
@@ -77,7 +102,7 @@ public class MongoDaoProperties {
         }
 
         public Integer getPort() {
-            return ofNullable(port).orElse(ServerAddress.defaultPort());
+            return port;
         }
 
         public void setPort(Integer port) {

--- a/core/dao-mongo/src/main/java/uk/gov/dwp/queue/triage/core/dao/mongo/configuration/MongoDaoProperties.java
+++ b/core/dao-mongo/src/main/java/uk/gov/dwp/queue/triage/core/dao/mongo/configuration/MongoDaoProperties.java
@@ -1,12 +1,11 @@
 package uk.gov.dwp.queue.triage.core.dao.mongo.configuration;
 
-import com.mongodb.MongoClient;
-import com.mongodb.MongoClientOptions;
-import com.mongodb.MongoClientURI;
 import com.mongodb.ServerAddress;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 import static java.util.Optional.ofNullable;
@@ -15,34 +14,25 @@ import static java.util.Optional.ofNullable;
 @ConfigurationProperties(prefix = "dao.mongo")
 public class MongoDaoProperties {
 
-    private Optional<String> uri = Optional.empty();
-    private Optional<String> host = Optional.empty();
-    private Optional<Integer> port = Optional.empty();
+    private List<MongoServerAddress> serverAddresses = new ArrayList<>();
     private Optional<String> dbName = Optional.empty();
     private Collection failedMessage = new Collection();
     private MongoOptions options = new MongoOptions();
 
-    public String getHost() {
-        return host.orElse(ServerAddress.defaultHost());
+    public List<MongoServerAddress> getServerAddresses() {
+        return serverAddresses;
     }
 
-    public void setHost(String host) {
-        this.host = ofNullable(host);
-    }
-
-    public Integer getPort() {
-        return port.orElse(ServerAddress.defaultPort());
-    }
-
-    public void setPort(Integer port) {
-        this.port = ofNullable(port);
+    public void setServerAddresses(List<MongoServerAddress> serverAddresses) {
+        this.serverAddresses = serverAddresses;
     }
 
     public String getDbName() {
         return dbName.orElse("queue-triage");
     }
 
-    public void setDbName(String dbName) { this.dbName = ofNullable(dbName);
+    public void setDbName(String dbName) {
+        this.dbName = ofNullable(dbName);
     }
 
     public Collection getFailedMessage() {
@@ -53,25 +43,12 @@ public class MongoDaoProperties {
         this.failedMessage = failedMessage;
     }
 
-    public MongoClient createClient() {
-        return uri
-                .map(s -> new MongoClient(new MongoClientURI(s)))
-                .orElseGet(() -> new MongoClient(getHost(), getPort()));
-    }
-
     public MongoOptions getOptions() {
         return options;
     }
 
     public void setOptions(MongoOptions options) {
         this.options = options;
-    }
-
-    public MongoClientOptions mongoClientOptions() {
-        return new MongoClientOptions.Builder()
-                .sslEnabled(options.ssl.enabled)
-                .sslInvalidHostNameAllowed(options.ssl.invalidHostnameAllowed)
-                .build();
     }
 
     public static class Collection {
@@ -84,6 +61,27 @@ public class MongoDaoProperties {
 
         public void setName(String name) {
             this.name = name;
+        }
+    }
+
+    public static class MongoServerAddress {
+        private String host;
+        private Integer port;
+
+        public String getHost() {
+            return ofNullable(host).orElse(ServerAddress.defaultHost());
+        }
+
+        public void setHost(String host) {
+            this.host = host;
+        }
+
+        public Integer getPort() {
+            return ofNullable(port).orElse(ServerAddress.defaultPort());
+        }
+
+        public void setPort(Integer port) {
+            this.port = port;
         }
     }
 
@@ -103,8 +101,16 @@ public class MongoDaoProperties {
             private boolean enabled;
             private boolean invalidHostnameAllowed;
 
+            public boolean isEnabled() {
+                return enabled;
+            }
+
             public void setEnabled(boolean enabled) {
                 this.enabled = enabled;
+            }
+
+            public boolean isInvalidHostnameAllowed() {
+                return invalidHostnameAllowed;
             }
 
             public void setInvalidHostnameAllowed(boolean invalidHostnameAllowed) {

--- a/core/dao-mongo/src/main/resources/mongo-queue-triage-roles.sh
+++ b/core/dao-mongo/src/main/resources/mongo-queue-triage-roles.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+MONGO_DB_ADDRESS=${MONGO_DB_ADDRESS:-"localhost:27017/queue-triage"}
+MONGO_COLLECTION=${MONGO_COLLECTION:-"failedMessage"}
+MONGO_ADMIN_USER=${MONGO_ADMIN_USER:-"admin"}
+MONGO_ADMIN_PASSWORD=${MONGO_ADMIN_PASSWORD:-"Passw0rd"}
+MONGO_ADMIN_DB=${MONGO_ADMIN_DB:-"admin"}
+
+echo "Connecting to ${MONGO_DB_ADDRESS} as ${MONGO_ADMIN_USER}"
+
+mongo --username=${MONGO_ADMIN_USER} \
+      --password=${MONGO_ADMIN_PASSWORD} \
+      --authenticationDatabase=${MONGO_ADMIN_DB} \
+      ${MONGO_DB_ADDRESS} <<!
+db.createRole({
+  role: "failedMessageReadOnly",
+    privileges: [
+      { resource: { db: "queue-triage", collection: "failedMessage" }, actions: [ "find" ] }
+    ],
+    roles: []
+})
+db.createRole({
+  role: "failedMessageReadWrite",
+  privileges: [
+    { resource: { db: "queue-triage", collection: "failedMessage" }, actions: [ "update", "insert", "remove" ] }
+  ],
+  roles: [
+    { role: "failedMessageReadOnly", db: "queue-triage" }
+  ]
+})
+!

--- a/core/dao-mongo/src/main/resources/mongo-queue-triage-users.sh
+++ b/core/dao-mongo/src/main/resources/mongo-queue-triage-users.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+MONGO_DB_ADDRESS=${MONGO_DB_ADDRESS:-"localhost:27017/queue-triage"}
+MONGO_COLLECTION=${MONGO_COLLECTION:-"failedMessage"}
+MONGO_ADMIN_USER=${MONGO_ADMIN_USER:-"admin"}
+MONGO_ADMIN_PASSWORD=${MONGO_ADMIN_PASSWORD:-"Passw0rd"}
+MONGO_ADMIN_DB=${MONGO_ADMIN_DB:-"admin"}
+
+echo "Connecting to ${MONGO_DB_ADDRESS} as ${MONGO_ADMIN_USER}"
+
+mongo --username=${MONGO_ADMIN_USER} \
+      --password=${MONGO_ADMIN_PASSWORD} \
+      --authenticationDatabase=${MONGO_ADMIN_DB} \
+      ${MONGO_DB_ADDRESS} <<!
+db.createUser({
+  user: "failedMessageUser",
+  pwd: "Passw0rd",
+  roles: [
+    "failedMessageReadWrite"
+  ]
+})
+!

--- a/core/dao-mongo/src/test/java/uk/gov/dwp/queue/triage/core/dao/mongo/configuration/MongoDaoPropertiesTest.java
+++ b/core/dao-mongo/src/test/java/uk/gov/dwp/queue/triage/core/dao/mongo/configuration/MongoDaoPropertiesTest.java
@@ -1,0 +1,165 @@
+package uk.gov.dwp.queue.triage.core.dao.mongo.configuration;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+import org.hamcrest.TypeSafeMatcher;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.config.YamlPropertiesFactoryBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.PropertiesPropertySource;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.core.io.ClassPathResource;
+import uk.gov.dwp.queue.triage.core.dao.mongo.configuration.MongoDaoProperties.Collection;
+import uk.gov.dwp.queue.triage.core.dao.mongo.configuration.MongoDaoProperties.MongoOptions;
+import uk.gov.dwp.queue.triage.core.dao.mongo.configuration.MongoDaoProperties.MongoOptions.SSL;
+import uk.gov.dwp.queue.triage.core.dao.mongo.configuration.MongoDaoProperties.MongoServerAddress;
+
+import java.util.Optional;
+import java.util.Properties;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+
+public class MongoDaoPropertiesTest {
+
+    private final MongoDaoProperties underTest = new MongoDaoProperties();
+    private final MongoOptions mongoOptions = new MongoOptions();
+    private final SSL ssl = new SSL();
+
+    @Before
+    public void setUp() {
+        underTest.setOptions(mongoOptions);
+        mongoOptions.setSsl(ssl);
+    }
+
+    @Test
+    public void createMongoConfigurationWithMultipleServers() throws Exception {
+        AnnotationConfigApplicationContext applicationContext = createApplicationContext("mongo-dao-multiple-servers-and-auth.yml");
+
+        MongoDaoProperties properties = applicationContext.getBean(MongoDaoProperties.class);
+
+        assertThat(properties.getServerAddresses(), contains(
+                serverAddress("db1.server.com", 27017),
+                serverAddress("db2.server.com", 27017)
+        ));
+        assertThat(properties.getDbName(), is("someDatabase"));
+        assertThat(properties.getFailedMessage(), is(collection("someCollection", Optional.of("failedMessageUser"), Optional.of("Passw0rd"))));
+        assertThat(properties.getOptions(), allOf(
+                sslEnabled(true),
+                invalidHostnameAllowed(true)
+        ));
+    }
+
+    @Test
+    public void createDefaultMongoConfiguration() {
+        AnnotationConfigApplicationContext applicationContext = createApplicationContext("mongo-dao-defaults.yml");
+
+        MongoDaoProperties properties = applicationContext.getBean(MongoDaoProperties.class);
+
+        assertThat(properties.getServerAddresses(), contains(
+                serverAddress("localhost", 27017)
+        ));
+        assertThat(properties.getDbName(), is("queue-triage"));
+        assertThat(properties.getFailedMessage(), is(collection("failedMessage", Optional.empty(), Optional.empty())));
+        assertThat(properties.getOptions(), allOf(
+                sslEnabled(false),
+                invalidHostnameAllowed(false)
+        ));
+    }
+
+    public TypeSafeDiagnosingMatcher<MongoOptions> sslEnabled(boolean sslEnabled) {
+        return new TypeSafeDiagnosingMatcher<MongoOptions>() {
+            @Override
+            protected boolean matchesSafely(MongoOptions mongoOptions, Description description) {
+                description.appendText("was ").appendValue(mongoOptions.getSsl().isEnabled());
+                return mongoOptions.getSsl().isEnabled() == sslEnabled;
+            }
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("dao.mongo.options.ssl.enabled=").appendValue(sslEnabled);
+            }
+        };
+    }
+
+    public TypeSafeDiagnosingMatcher<MongoOptions> invalidHostnameAllowed(boolean invalidHostnameAllowed) {
+        return new TypeSafeDiagnosingMatcher<MongoOptions>() {
+            @Override
+            protected boolean matchesSafely(MongoOptions mongoOptions, Description description) {
+                description.appendText("was ").appendValue(mongoOptions.getSsl().isInvalidHostnameAllowed());
+                return mongoOptions.getSsl().isEnabled() == invalidHostnameAllowed;
+            }
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("dao.mongo.options.ssl.invalidHostnameAllowed=").appendValue(invalidHostnameAllowed);
+            }
+        };
+    }
+
+    public TypeSafeMatcher<MongoServerAddress> serverAddress(String host, int port) {
+        return new TypeSafeMatcher<MongoServerAddress>() {
+            @Override
+            protected boolean matchesSafely(MongoServerAddress serverAddress) {
+                return host.equals(serverAddress.getHost()) && (port == serverAddress.getPort());
+            }
+
+            @Override
+            public void describeTo(Description description) {
+                description
+                        .appendText("dao.mongo.serverAddresses.host=").appendText(host)
+                        .appendText(", dao.mongo.serverAddress.port=").appendValue(port);
+            }
+        };
+    }
+
+    public TypeSafeDiagnosingMatcher<Collection> collection(String name, Optional<String> username, Optional<String> password) {
+        return new TypeSafeDiagnosingMatcher<Collection>() {
+            @Override
+            protected boolean matchesSafely(Collection collection, Description description) {
+                return name.equals(collection.getName())
+                        && username.equals(collection.getUsername())
+                        && password.equals(collection.getPassword());
+            }
+
+            @Override
+            public void describeTo(Description description) {
+                description
+                        .appendText("dao.mongo.").appendText(name).appendText(".username=").appendValue(username)
+                        .appendText(", dao.mongo.").appendText(name).appendText(".password=").appendValue(password);
+            }
+        };
+    }
+
+    private AnnotationConfigApplicationContext createApplicationContext(String yamlFilename) {
+        AnnotationConfigApplicationContext applicationContext = new AnnotationConfigApplicationContext();
+        applicationContext.setEnvironment(createEnvironment(yamlFilename));
+        applicationContext.register(DummyConfiguration.class);
+        applicationContext.refresh();
+        return applicationContext;
+    }
+
+    private StandardEnvironment createEnvironment(String yamlFilename) {
+        StandardEnvironment environment = new StandardEnvironment();
+        environment.getPropertySources().addFirst(new PropertiesPropertySource("mongo-dao-properties", loadPropertiesFromYaml(yamlFilename)));
+        return environment;
+    }
+
+    public Properties loadPropertiesFromYaml(String yamlFilename) {
+        YamlPropertiesFactoryBean yamlPropertiesFactoryBean = new YamlPropertiesFactoryBean();
+        yamlPropertiesFactoryBean.setResources(new ClassPathResource(yamlFilename));
+        return yamlPropertiesFactoryBean.getObject();
+    }
+
+    @Configuration
+    @EnableConfigurationProperties(MongoDaoProperties.class)
+    public static class DummyConfiguration {
+
+    }
+
+}

--- a/core/dao-mongo/src/test/resources/mongo-dao-defaults.yml
+++ b/core/dao-mongo/src/test/resources/mongo-dao-defaults.yml
@@ -1,0 +1,5 @@
+dao:
+  mongo:
+    serverAddresses:
+    - host: localhost
+      port: 27017

--- a/core/dao-mongo/src/test/resources/mongo-dao-multiple-servers-and-auth.yml
+++ b/core/dao-mongo/src/test/resources/mongo-dao-multiple-servers-and-auth.yml
@@ -1,0 +1,16 @@
+dao:
+  mongo:
+    serverAddresses:
+      - host: db1.server.com
+        port: 27017
+      - host: db2.server.com
+        port: 27017
+    options:
+      ssl:
+        enabled: true
+        invalidHostnameAllowed: true
+    dbName: someDatabase
+    failedMessage:
+      name: someCollection
+      username: failedMessageUser
+      password: Passw0rd

--- a/core/dao/BUCK
+++ b/core/dao/BUCK
@@ -11,6 +11,7 @@ java_library(
     visibility = [
         '//core/dao-mongo:queue-triage-core-dao-mongo',
         '//core/dao-mongo:test',
+        '//core/resend:test-spring',
         '//core/search:queue-triage-core-search-mongo',
         '//core/search:test-mongo',
         '//core/server:queue-triage-core-server',

--- a/core/message-classification/src/main/java/uk/gov/dwp/queue/triage/core/classification/server/executor/MessageClassificationExecutorService.java
+++ b/core/message-classification/src/main/java/uk/gov/dwp/queue/triage/core/classification/server/executor/MessageClassificationExecutorService.java
@@ -63,7 +63,7 @@ public class MessageClassificationExecutorService {
                 executionFrequency,
                 timeUnit
         );
-        scheduleAtAFixedRate(0);
+        scheduleAtAFixedRate(0).isDone();
     }
 
     @PUT
@@ -86,12 +86,13 @@ public class MessageClassificationExecutorService {
         LOGGER.info("Execution of the MessageClassificationService stopped");
     }
 
-    private void scheduleAtAFixedRate(long initialDelay) {
+    private ScheduledFuture<?> scheduleAtAFixedRate(long initialDelay) {
         futureTask = this.scheduledExecutorService.scheduleAtFixedRate(
                 runnable,
                 initialDelay,
                 executionFrequency,
                 timeUnit
         );
+        return futureTask;
     }
 }

--- a/core/resend/BUCK
+++ b/core/resend/BUCK
@@ -82,6 +82,7 @@ java_test(
     name = "test-spring",
     srcs = glob(["src/test/java/**/spring/**/*.java"]),
     deps = RESEND_SPRING_DEPENDENCIES + [
+        "//core/dao:queue-triage-core-dao",
         "//core/jms:queue-triage-core-jms",
         "//core/jms:queue-triage-core-jms-spring",
         "//core/resend:queue-triage-core-resend",

--- a/core/resend/src/main/java/uk/gov/dwp/queue/triage/core/resend/ResendScheduledExecutorService.java
+++ b/core/resend/src/main/java/uk/gov/dwp/queue/triage/core/resend/ResendScheduledExecutorService.java
@@ -56,7 +56,7 @@ public class ResendScheduledExecutorService {
                 executionFrequency,
                 timeUnit
         );
-        scheduleAtAFixedRate(0);
+        scheduleAtAFixedRate(0).isDone();
     }
 
     public void pause() {
@@ -81,12 +81,13 @@ public class ResendScheduledExecutorService {
         return brokerName;
     }
 
-    private void scheduleAtAFixedRate(long initialDelay) {
+    private ScheduledFuture<?> scheduleAtAFixedRate(long initialDelay) {
         futureTask = this.scheduledExecutorService.scheduleAtFixedRate(
                 runnable,
                 initialDelay,
                 executionFrequency,
                 timeUnit
         );
+        return futureTask;
     }
 }

--- a/core/resend/src/main/java/uk/gov/dwp/queue/triage/core/resend/ResendScheduledExecutorsResource.java
+++ b/core/resend/src/main/java/uk/gov/dwp/queue/triage/core/resend/ResendScheduledExecutorsResource.java
@@ -11,9 +11,9 @@ import java.util.Map;
 @Path("/admin/executor/message-resend/{brokerName}")
 public class ResendScheduledExecutorsResource {
 
-    private Map<String, ResendScheduledExecutorService> resendScheduledExecutors = new HashMap<>();
+    private final Map<String, ResendScheduledExecutorService> resendScheduledExecutors;
 
-    public void setResendScheduledExecutors(Map<String, ResendScheduledExecutorService> resendScheduledExecutors) {
+    public ResendScheduledExecutorsResource(Map<String, ResendScheduledExecutorService> resendScheduledExecutors) {
         this.resendScheduledExecutors = resendScheduledExecutors;
     }
 

--- a/core/resend/src/main/java/uk/gov/dwp/queue/triage/core/resend/spring/FailedMessageSenderBeanDefinitionFactory.java
+++ b/core/resend/src/main/java/uk/gov/dwp/queue/triage/core/resend/spring/FailedMessageSenderBeanDefinitionFactory.java
@@ -13,6 +13,7 @@ public class FailedMessageSenderBeanDefinitionFactory {
         return genericBeanDefinition(FailedMessageSender.class)
                 .addConstructorArgReference(messageSenderDelegate)
                 .addConstructorArgReference("failedMessageService")
+                .addDependsOn("failedMessageDao")
                 .getBeanDefinition();
     }
 

--- a/core/resend/src/main/java/uk/gov/dwp/queue/triage/core/resend/spring/ResendBeanDefinitionFactory.java
+++ b/core/resend/src/main/java/uk/gov/dwp/queue/triage/core/resend/spring/ResendBeanDefinitionFactory.java
@@ -9,15 +9,9 @@ import org.springframework.core.env.Environment;
 import uk.gov.dwp.queue.triage.core.jms.activemq.spring.ActiveMQConnectionFactoryBeanDefinitionFactory;
 import uk.gov.dwp.queue.triage.core.jms.spring.JmsTemplateBeanDefinitionFactory;
 import uk.gov.dwp.queue.triage.core.jms.spring.SpringMessageSenderBeanDefinitionFactory;
-import uk.gov.dwp.queue.triage.core.resend.ResendScheduledExecutorService;
-import uk.gov.dwp.queue.triage.core.resend.ResendScheduledExecutorsResource;
 
-import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class ResendBeanDefinitionFactory implements BeanDefinitionRegistryPostProcessor {
 
@@ -121,14 +115,6 @@ public class ResendBeanDefinitionFactory implements BeanDefinitionRegistryPostPr
 
     @Override
     public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {
-        final Map<String, ResendScheduledExecutorService> resendScheduledExecutors =
-                Stream.of(beanFactory.getBeanNamesForType(ResendScheduledExecutorService.class))
-                        .map(beanName -> beanFactory.getBean(beanName, ResendScheduledExecutorService.class))
-                        .collect(Collectors.toMap(
-                                ResendScheduledExecutorService::getBrokerName,
-                                Function.identity()
-                        ));
-        beanFactory.getBean(ResendScheduledExecutorsResource.class).setResendScheduledExecutors(resendScheduledExecutors);
     }
 
     private boolean hasMoreBrokers(int index) {

--- a/core/resend/src/main/java/uk/gov/dwp/queue/triage/core/resend/spring/configuration/ResendFailedMessageConfiguration.java
+++ b/core/resend/src/main/java/uk/gov/dwp/queue/triage/core/resend/spring/configuration/ResendFailedMessageConfiguration.java
@@ -9,11 +9,16 @@ import uk.gov.dwp.migration.mongo.demo.cxf.client.ResourceRegistry;
 import uk.gov.dwp.queue.triage.core.jms.activemq.spring.ActiveMQConnectionFactoryBeanDefinitionFactory;
 import uk.gov.dwp.queue.triage.core.jms.spring.JmsTemplateBeanDefinitionFactory;
 import uk.gov.dwp.queue.triage.core.jms.spring.SpringMessageSenderBeanDefinitionFactory;
+import uk.gov.dwp.queue.triage.core.resend.ResendScheduledExecutorService;
 import uk.gov.dwp.queue.triage.core.resend.ResendScheduledExecutorsResource;
 import uk.gov.dwp.queue.triage.core.resend.spring.FailedMessageSenderBeanDefinitionFactory;
 import uk.gov.dwp.queue.triage.core.resend.spring.ResendBeanDefinitionFactory;
 import uk.gov.dwp.queue.triage.core.resend.spring.ResendFailedMessageServiceBeanDefinitionFactory;
 import uk.gov.dwp.queue.triage.core.resend.spring.ResendScheduledExecutorServiceBeanDefinitionFactory;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Configuration
 @Import({
@@ -35,7 +40,11 @@ public class ResendFailedMessageConfiguration {
     }
 
     @Bean
-    public ResendScheduledExecutorsResource resendScheduledExecutorsResource(ResourceRegistry resourceRegistry) {
-        return resourceRegistry.add(new ResendScheduledExecutorsResource());
+    public ResendScheduledExecutorsResource resendScheduledExecutorsResource(ResourceRegistry resourceRegistry,
+                                                                             List<ResendScheduledExecutorService> resendScheduledExecutorServices) {
+        return resourceRegistry.add(new ResendScheduledExecutorsResource(
+                resendScheduledExecutorServices
+                        .stream()
+                        .collect(Collectors.toMap(ResendScheduledExecutorService::getBrokerName, Function.identity()))));
     }
 }

--- a/core/resend/src/test/java/uk/gov/dwp/queue/triage/core/resend/spring/ResendBeanDefinitionFactoryTest.java
+++ b/core/resend/src/test/java/uk/gov/dwp/queue/triage/core/resend/spring/ResendBeanDefinitionFactoryTest.java
@@ -11,6 +11,7 @@ import org.springframework.core.env.PropertiesPropertySource;
 import org.springframework.core.env.StandardEnvironment;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.jms.core.JmsTemplate;
+import uk.gov.dwp.queue.triage.core.dao.FailedMessageDao;
 import uk.gov.dwp.queue.triage.core.jms.spring.SpringMessageSender;
 import uk.gov.dwp.queue.triage.core.resend.FailedMessageSender;
 import uk.gov.dwp.queue.triage.core.resend.ResendFailedMessageService;
@@ -128,6 +129,11 @@ public class ResendBeanDefinitionFactoryTest {
         @Bean
         public FailedMessageService failedMessageService() {
             return mock(FailedMessageService.class);
+        }
+
+        @Bean
+        public FailedMessageDao failedMessageDao() {
+            return mock(FailedMessageDao.class);
         }
     }
 }

--- a/core/server/src/main/resources/application.yml
+++ b/core/server/src/main/resources/application.yml
@@ -6,8 +6,9 @@ cxf:
 
 dao:
   mongo:
-    host: localhost
-    port: 27017
+    serverAddresses:
+      - host: localhost
+        port: 27017
     options:
       ssl:
         enabled: false

--- a/project
+++ b/project
@@ -16,6 +16,7 @@ sed -i'.bak' 's#"file://$MODULE_DIR$/src" isTestSource="false"#"file://$MODULE_D
 sed -i'.bak' 's#"file://$MODULE_DIR$/src" isTestSource="false"#"file://$MODULE_DIR$/src/test/resources" type="java-test-resource"#' core/activemq/core_activemq.iml
 sed -i'.bak' 's#"file://$MODULE_DIR$/src" isTestSource="false"#"file://$MODULE_DIR$/src/test/resources" type="java-test-resource"#' web/mustache/web_mustache.iml
 sed -i'.bak' 's#"file://$MODULE_DIR$/src" isTestSource="false"#"file://$MODULE_DIR$/src/main/resources" type="java-resource"#' core/server/core_server.iml
+sed -i'.bak' 's#"file://$MODULE_DIR$/src" isTestSource="false"#"file://$MODULE_DIR$/src/test/resources" type="java-test-resource"#' core/dao-mongo/core_dao_mongo.iml
 sed -i'.bak' 's#"file://$MODULE_DIR$/src" isTestSource="false"#"file://$MODULE_DIR$/src/main/resources" type="java-resource"#' core/dao-mongo-test-support/core_dao_mongo_test_support.iml
 sed -i'.bak' 's#"file://$MODULE_DIR$/src" isTestSource="false"#"file://$MODULE_DIR$/src/main/resources" type="java-resource"#' core/component-test/core_component_test.iml
 sed -i'.bak' 's#/src/test" isTestSource="true"#/src/test/java" isTestSource="true"#' core/jms/core_jms.iml


### PR DESCRIPTION
1. Remove the post processing of the ResendScheduledExecutorResource which was causing some Beans not to be instantiated properly.
2. Added support for multiple servers and (optional) authentication
```yaml
dao:
  mongo:
    serverAddresses:
      - host: localhost
        port: 27017
    failedMessage:
      name: failedMessage
      username: failedMessageUser
      password: Passw0rd
```
3. Wait for jobs to complete when executing requests via the REST endpoints (only currently used by tests)