### PR TITLE
Generate JGiven HTML output

### DIFF
--- a/core/component-test/BUCK
+++ b/core/component-test/BUCK
@@ -82,6 +82,6 @@ java_test(
 # buck build //core/component-test:generate-jgiven-html-reports
 genrule(
     name = "generate-jgiven-html-reports",
-    cmd  = "$(exe //lib/test:jgiven-html5-report-with-deps) --format=html --sourceDir=/Users/anmcghie/sandpit/queue-triage/buck-out/gen/core/component-test/jgiven-reports --targetDir=$OUT",
+    cmd  = "$(exe //lib/test:jgiven-html5-report-with-deps) --format=html --sourceDir=`pwd`/../jgiven-reports --targetDir=$OUT",
     out  = "jgiven-html-reports",
 )

--- a/core/component-test/BUCK
+++ b/core/component-test/BUCK
@@ -73,4 +73,15 @@ java_test(
     visibility = [
         "PUBLIC"
     ],
+    # TODO: Can we pass $(location :test) or something similar into vm_args?
+    vm_args = [
+        "-Djgiven.report.dir=buck-out/gen/core/component-test/jgiven-reports",
+    ],
+)
+
+# buck build //core/component-test:generate-jgiven-html-reports
+genrule(
+    name = "generate-jgiven-html-reports",
+    cmd  = "$(exe //lib/test:jgiven-html5-report-with-deps) --format=html --sourceDir=/Users/anmcghie/sandpit/queue-triage/buck-out/gen/core/component-test/jgiven-reports --targetDir=$OUT",
+    out  = "jgiven-html-reports",
 )

--- a/lib/test/BUCK
+++ b/lib/test/BUCK
@@ -11,6 +11,7 @@ prebuilt_jar(name='hamcrest-optional', binary_jar=':hamcrest-optional-mvn', visi
 prebuilt_jar(name='jansi', binary_jar=':jansi-mvn')
 prebuilt_jar(name='jgiven-core', binary_jar=':jgiven-core-mvn', visibility=["PUBLIC"])
 prebuilt_jar(name='jgiven-junit', binary_jar=':jgiven-junit-mvn')
+prebuilt_jar(name='jgiven-html-app', binary_jar=':jgiven-html-app-mvn')
 prebuilt_jar(name='jgiven-html5-report', binary_jar=':jgiven-html5-report-mvn')
 prebuilt_jar(name='jgiven-spring', binary_jar=':jgiven-spring-mvn', visibility=["PUBLIC"])
 prebuilt_jar(name='junit', binary_jar=':junit-mvn', visibility=["PUBLIC"])
@@ -31,6 +32,7 @@ remote_file(name='hamcrest-library-mvn', out='hamcrest-library-1.3.jar', url='mv
 remote_file(name='hamcrest-optional-mvn', out='hamcrest-optional-1.0.2.jar', url='mvn:com.spotify:hamcrest-optional:jar:1.0.2', sha1='7b5261ec45db30fad35847022bd89901b7216df4')
 remote_file(name='jansi-mvn', out='jansi-1.15.jar', url='mvn:org.fusesource.jansi:jansi:jar:1.15', sha1='5292bc138cb1412ea940551c667f8ec4da52d249')
 remote_file(name='jgiven-core-mvn', out='jgiven-core-0.15.1.jar', url='mvn:com.tngtech.jgiven:jgiven-core:jar:0.15.1', sha1='fc2880aa9d74adc6f8a72b5696439d13b8f530dc')
+remote_file(name='jgiven-html-app-mvn', out='jgiven-html-app-0.15.1.jar', url='mvn:com.tngtech.jgiven:jgiven-html-app:jar:0.15.1', sha1='4e34aee571bc4136cd05ca2a34ccef42c56c2bed')
 remote_file(name='jgiven-html5-report-mvn', out='jgiven-html5-report-0.15.1.jar', url='mvn:com.tngtech.jgiven:jgiven-html5-report:jar:0.15.1', sha1='6d011ce29cdf5f6ab1c5863ba523fa9973463b29')
 remote_file(name='jgiven-junit-mvn', out='jgiven-junit-0.15.1.jar', url='mvn:com.tngtech.jgiven:jgiven-junit:jar:0.15.1', sha1='0b862638480787929088efb28632d212a6701fa2')
 remote_file(name='jgiven-spring-mvn', out='jgiven-spring-0.15.1.jar', url='mvn:com.tngtech.jgiven:jgiven-spring:jar:0.15.1', sha1='312abfa016e04e88fe73e4a97fcc396534c82d9d')
@@ -59,7 +61,6 @@ java_library(
     exported_deps = [
         ':jansi',
         ':jgiven-core',
-        ':jgiven-html5-report',
         ':jgiven-junit',
         ':paranamer',
         '//lib:gson',
@@ -68,5 +69,20 @@ java_library(
     ],
     visibility = [
         "PUBLIC",
+    ],
+)
+
+java_binary(
+    name = 'jgiven-html5-report-with-deps',
+    main_class = "com.tngtech.jgiven.report.ReportGenerator",
+    deps = [
+        ':jgiven',
+        ':jgiven-html-app',
+        ':jgiven-html5-report',
+        '//lib/slf4j:slf4j-api',
+        '//lib/slf4j:slf4j-simple',
+    ],
+    visibility = [
+        'PUBLIC',
     ],
 )

--- a/web/component-test/BUCK
+++ b/web/component-test/BUCK
@@ -48,5 +48,13 @@ java_test(
 #         "-Dbrowser=marionette",
 #         "-Dwebdriver.gecko.driver=/opt/geckodriver/current/geckodriver"
         "-Dbrowser=phantomjs",
+        "-Djgiven.report.dir=buck-out/gen/web/component-test/jgiven-reports",
     ]
+)
+
+# buck build //web/component-test:generate-jgiven-html-reports
+genrule(
+    name = "generate-jgiven-html-reports",
+    cmd  = "$(exe //lib/test:jgiven-html5-report-with-deps) --format=html --sourceDir=`pwd`/../jgiven-reports --targetDir=$OUT",
+    out  = "jgiven-html-reports",
 )


### PR DESCRIPTION
Generate JGiven HTML output which could then be published to S3, GitHub wiki/pages.

Currently output is published to
* `buck-out/gen/core/component-test/generate-jgiven-html-reports/jgiven-html-reports`
* `buck-out/gen/web/component-test/generate-jgiven-html-reports/jgiven-html-reports`

Resolves #64 