### PR TITLE
Issue 56 - Configurable Message Classification executor

### DIFF
--- a/core/message-classification/BUCK
+++ b/core/message-classification/BUCK
@@ -67,24 +67,12 @@ java_library(
     ],
 )
 
-java_library(
-    name = 'test-resources',
-    resources = glob([
-        'src/test/resources/*.yml'
-    ]),
-    resources_root = 'src/test/resources',
-    visibility = [
-        '//core/message-classification:test-server'
-    ]
-)
-
 java_test(
     name = 'test-server',
     srcs = glob(['src/test/java/**/server/**/*.java']),
     deps = [
         ':queue-triage-core-message-classification',
         ':queue-triage-core-message-classification-server',
-        ':test-resources',
         '//core/domain:queue-triage-core-domain',
         '//core/search:queue-triage-core-search',
         '//lib:commons-lang3',

--- a/core/message-classification/BUCK
+++ b/core/message-classification/BUCK
@@ -53,6 +53,7 @@ java_library(
         "//lib/javax:javax-ws-rs-api",
         "//lib/slf4j:slf4j-api",
         "//lib/spring:spring-beans",
+        "//lib/spring:spring-boot",
         "//lib/spring:spring-context",
         ':queue-triage-core-message-classification',
         '//common/id:queue-triage-common-id',
@@ -66,18 +67,35 @@ java_library(
     ],
 )
 
+java_library(
+    name = 'test-resources',
+    resources = glob([
+        'src/test/resources/*.yml'
+    ]),
+    resources_root = 'src/test/resources',
+    visibility = [
+        '//core/message-classification:test-server'
+    ]
+)
+
 java_test(
     name = 'test-server',
     srcs = glob(['src/test/java/**/server/**/*.java']),
     deps = [
         ':queue-triage-core-message-classification',
         ':queue-triage-core-message-classification-server',
+        ':test-resources',
         '//core/domain:queue-triage-core-domain',
         '//core/search:queue-triage-core-search',
         '//lib:commons-lang3',
+        '//lib:snakeyaml',
+        '//lib/hibernate-validator:hibernate-validator',
         '//lib/jackson:jackson-annotations',
         '//lib/slf4j:slf4j-api',
 #         '//lib/slf4j:slf4j-simple',
+        '//lib/spring:spring-boot',
+        '//lib/spring:spring-core',
+        '//lib/spring:spring-core-dependencies',
         '//lib/test:common',
     ],
     vm_args = [

--- a/core/message-classification/src/main/java/uk/gov/dwp/queue/triage/core/classification/server/configuration/MessageClassificationConfiguration.java
+++ b/core/message-classification/src/main/java/uk/gov/dwp/queue/triage/core/classification/server/configuration/MessageClassificationConfiguration.java
@@ -1,5 +1,6 @@
 package uk.gov.dwp.queue.triage.core.classification.server.configuration;
 
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -16,9 +17,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 @Configuration
-@Import({
-        CxfConfiguration.class
-})
+@Import(CxfConfiguration.class)
+@EnableConfigurationProperties(MessageClassificationProperties.class)
 public class MessageClassificationConfiguration {
 
     @Bean
@@ -39,14 +39,15 @@ public class MessageClassificationConfiguration {
     }
 
     @Bean(initMethod = "start", destroyMethod = "stop")
-    public MessageClassificationExecutorService messageClassificationExecutorService(MessageClassificationService messageClassificationService,
+    public MessageClassificationExecutorService messageClassificationExecutorService(MessageClassificationProperties messageClassificationProperties,
+                                                                                     MessageClassificationService messageClassificationService,
                                                                                      ResourceRegistry resourceRegistry) {
         return resourceRegistry.add(new MessageClassificationExecutorService(
                 Executors.newSingleThreadScheduledExecutor(),
                 messageClassificationService,
-                0,
-                60,
-                TimeUnit.SECONDS
+                messageClassificationProperties.getInitialDelay(),
+                messageClassificationProperties.getFrequency(),
+                messageClassificationProperties.getTimeUnit()
         ));
     }
 }

--- a/core/message-classification/src/main/java/uk/gov/dwp/queue/triage/core/classification/server/configuration/MessageClassificationProperties.java
+++ b/core/message-classification/src/main/java/uk/gov/dwp/queue/triage/core/classification/server/configuration/MessageClassificationProperties.java
@@ -1,0 +1,39 @@
+package uk.gov.dwp.queue.triage.core.classification.server.configuration;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+@Component
+@ConfigurationProperties("messageClassification")
+public class MessageClassificationProperties {
+
+    private long initialDelay;
+    private long frequency;
+    private TimeUnit timeUnit;
+
+    public long getInitialDelay() {
+        return initialDelay;
+    }
+
+    public void setInitialDelay(long initialDelay) {
+        this.initialDelay = initialDelay;
+    }
+
+    public long getFrequency() {
+        return frequency;
+    }
+
+    public void setFrequency(long frequency) {
+        this.frequency = frequency;
+    }
+
+    public TimeUnit getTimeUnit() {
+        return timeUnit;
+    }
+
+    public void setTimeUnit(TimeUnit timeUnit) {
+        this.timeUnit = timeUnit;
+    }
+}

--- a/core/message-classification/src/test/java/uk/gov/dwp/queue/triage/core/classification/server/configuration/MessageClassificationPropertiesTest.java
+++ b/core/message-classification/src/test/java/uk/gov/dwp/queue/triage/core/classification/server/configuration/MessageClassificationPropertiesTest.java
@@ -1,0 +1,93 @@
+package uk.gov.dwp.queue.triage.core.classification.server.configuration;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matchers;
+import org.hamcrest.TypeSafeMatcher;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.beans.factory.config.YamlPropertiesFactoryBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.PropertiesPropertySource;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.validation.BindException;
+
+import java.util.Properties;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class MessageClassificationPropertiesTest {
+
+    private static final String YAML_PROPERTIES_TEMPLATE = "messageClassification:\n  initialDelay: %d\n  frequency:  %d\n  timeUnit: %s";
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void loadPropertiesWithValidTimeUnit() throws Exception {
+        String yaml = String.format(YAML_PROPERTIES_TEMPLATE, 0, 60, SECONDS);
+        AnnotationConfigApplicationContext applicationContext = createApplicationContext(yaml);
+
+        MessageClassificationProperties underTest = applicationContext.getBean(MessageClassificationProperties.class);
+
+        assertThat(underTest.getInitialDelay(), Matchers.is(0L));
+        assertThat(underTest.getFrequency(), Matchers.is(60L));
+        assertThat(underTest.getTimeUnit(), Matchers.is(SECONDS));
+    }
+
+    @Test
+    public void loadPropertiesWithInvalidTimeUnit() {
+        expectedException.expect(BeanCreationException.class);
+        expectedException.expectCause(bindException("timeUnit", "PINEAPPLES"));
+        String yaml = String.format(YAML_PROPERTIES_TEMPLATE, 0, 60, "PINEAPPLES");
+        AnnotationConfigApplicationContext applicationContext = createApplicationContext(yaml);
+
+        assertThat(applicationContext, Matchers.nullValue());
+    }
+
+    private TypeSafeMatcher<BindException> bindException(final String name, final String value) {
+        return new TypeSafeMatcher<BindException>() {
+            @Override
+            protected boolean matchesSafely(BindException bindException) {
+                return bindException.getFieldErrorCount() == 1 &&
+                        bindException.getFieldError(name).getRejectedValue().equals(value);
+            }
+
+            @Override
+            public void describeTo(Description description) {
+
+            }
+        };
+    }
+
+    private AnnotationConfigApplicationContext createApplicationContext(String yaml) {
+        AnnotationConfigApplicationContext applicationContext = new AnnotationConfigApplicationContext();
+        applicationContext.setEnvironment(createEnvironment(yaml));
+        applicationContext.register(DummyConfiguration.class);
+        applicationContext.refresh();
+        return applicationContext;
+    }
+
+    private StandardEnvironment createEnvironment(String yaml) {
+        StandardEnvironment environment = new StandardEnvironment();
+        environment.getPropertySources().addFirst(new PropertiesPropertySource("properties-under-test", loadPropertiesFromYaml(yaml)));
+        return environment;
+    }
+
+    public Properties loadPropertiesFromYaml(String yaml) {
+        YamlPropertiesFactoryBean yamlPropertiesFactoryBean = new YamlPropertiesFactoryBean();
+        yamlPropertiesFactoryBean.setResources(new ByteArrayResource(yaml.getBytes()));
+        return yamlPropertiesFactoryBean.getObject();
+    }
+
+    @Configuration
+    @EnableConfigurationProperties(MessageClassificationProperties.class)
+    public static class DummyConfiguration {
+
+    }
+}

--- a/core/server/src/main/resources/application.yml
+++ b/core/server/src/main/resources/application.yml
@@ -26,3 +26,8 @@ jms:
         resend:
           frequency: 60
           timeUnit: SECONDS
+
+messageClassification:
+  initialDelay: 0
+  frequency: 60
+  timeUnit: SECONDS

--- a/lib/spring/BUCK
+++ b/lib/spring/BUCK
@@ -13,6 +13,8 @@ prebuilt_jar(
         "//core/activemq:queue-triage-core-activemq",
         "//core/component-test:queue-triage-core-component-test",
         "//core/dao-mongo:queue-triage-core-dao-mongo",
+        "//core/message-classification:queue-triage-core-message-classification-server",
+        "//core/message-classification:test-server",
         "//core/search:queue-triage-core-search-mongo-spring",
     ]
 )
@@ -34,6 +36,7 @@ prebuilt_jar(
         "//core/activemq:test",
         "//core/jms:queue-triage-core-jms-spring",
         "//core/jms:test-spring",
+        "//core/message-classification:test-server",
         "//core/resend:queue-triage-core-resend-spring",
         "//core/resend:test-spring",
         "//core/search:queue-triage-core-search-mongo-spring",


### PR DESCRIPTION
Message classification job is now configurable from `application.yml`
### Example
```
messageClassification:
  initialDelay: 0
  frequency: 60
  timeUnit: SECONDS
```

Resolves #56 