### PR TITLE
Issue 21 - Failed Message Labels

### DIFF
--- a/core/client-test-support/src/main/java/uk/gov/dwp/queue/triage/core/client/FailedMessageResponseBuilder.java
+++ b/core/client-test-support/src/main/java/uk/gov/dwp/queue/triage/core/client/FailedMessageResponseBuilder.java
@@ -6,8 +6,10 @@ import uk.gov.dwp.queue.triage.id.FailedMessageId;
 
 import java.time.Instant;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import static uk.gov.dwp.queue.triage.id.FailedMessageId.newFailedMessageId;
 
@@ -15,12 +17,13 @@ public class FailedMessageResponseBuilder {
 
     private FailedMessageId failedMessageId;
     private String broker;
-    private Optional<String> destination;
+    private Optional<String> destination = Optional.empty();
     private Instant sentAt;
     private Instant failedAt;
     private String content;
     private FailedMessageStatus currentStatus;
-    private Map<String, Object> properties;
+    private Map<String, Object> properties = new HashMap<>();
+    private Set<String> labels = new HashSet<>();
 
     private FailedMessageResponseBuilder() {
     }
@@ -40,8 +43,8 @@ public class FailedMessageResponseBuilder {
                 failedAt,
                 content,
                 currentStatus,
-                properties
-        );
+                properties,
+                labels);
     }
 
     public FailedMessageResponseBuilder withNewFailedMessageId() {
@@ -96,6 +99,16 @@ public class FailedMessageResponseBuilder {
 
     public FailedMessageResponseBuilder withStatus(FailedMessageStatus status) {
         this.currentStatus = status;
+        return this;
+    }
+
+    public FailedMessageResponseBuilder withLabels(Set<String> labels) {
+        this.labels = (labels != null) ? labels : new HashSet<>();
+        return this;
+    }
+
+    public FailedMessageResponseBuilder withLabel(String label) {
+        this.labels.add(label);
         return this;
     }
 }

--- a/core/client-test-support/src/main/java/uk/gov/dwp/queue/triage/core/client/FailedMessageResponseMatcher.java
+++ b/core/client-test-support/src/main/java/uk/gov/dwp/queue/triage/core/client/FailedMessageResponseMatcher.java
@@ -24,8 +24,10 @@ public class FailedMessageResponseMatcher extends TypeSafeMatcher<FailedMessageR
     private Matcher<Instant> failedAtMatcher = new IsAnything<>();
     private Matcher<FailedMessageStatus> statusMatcher = new IsAnything<>();
     private Matcher<Map<? extends String, ? extends Object>> propertiesMatcher = new IsAnything<>();
+    private Matcher<Iterable<? extends String>> labelsMatcher = new IsAnything<>();
 
-    private FailedMessageResponseMatcher() { }
+    private FailedMessageResponseMatcher() {
+    }
 
     public static FailedMessageResponseMatcher aFailedMessage() {
         return new FailedMessageResponseMatcher();
@@ -81,6 +83,11 @@ public class FailedMessageResponseMatcher extends TypeSafeMatcher<FailedMessageR
         return this;
     }
 
+    public FailedMessageResponseMatcher withLabels(Matcher<Iterable<? extends String>> labelsMatcher) {
+        this.labelsMatcher = labelsMatcher;
+        return this;
+    }
+
     @Override
     protected boolean matchesSafely(FailedMessageResponse item) {
         return failedMessageIdMatcher.matches(item.getFailedMessageId())
@@ -90,20 +97,27 @@ public class FailedMessageResponseMatcher extends TypeSafeMatcher<FailedMessageR
                 && sentAtMatcher.matches(item.getSentAt())
                 && failedAtMatcher.matches(item.getFailedAt())
                 && statusMatcher.matches(item.getCurrentStatus())
-                && propertiesMatcher.matches(item.getProperties());
+                && propertiesMatcher.matches(item.getProperties())
+                && labelsMatcher.matches(item.getLabels());
     }
 
     @Override
     public void describeTo(Description description) {
-        description
-                .appendText("failedMessageId is ").appendDescriptionOf(failedMessageIdMatcher)
-                .appendText(" content is ").appendDescriptionOf(contentMatcher)
-                .appendText(" broker is ").appendDescriptionOf(brokerMatcher)
-                .appendText(" destination is ").appendDescriptionOf(destinationMatcher)
-                .appendText(" sentAt is ").appendDescriptionOf(sentAtMatcher)
-                .appendText(" failedAt is ").appendDescriptionOf(failedAtMatcher)
-                .appendText(" status is").appendDescriptionOf(statusMatcher)
-                .appendText(" properties are ").appendDescriptionOf(propertiesMatcher)
+        addMatcher(description, "failedMessageId is ", failedMessageIdMatcher);
+        addMatcher(description, "content is ", contentMatcher);
+        addMatcher(description, "broker is ", brokerMatcher);
+        addMatcher(description, "destination is ", destinationMatcher);
+        addMatcher(description, "sentAt is ", sentAtMatcher);
+        addMatcher(description, "failedAt is ", failedAtMatcher);
+        addMatcher(description, "status is", statusMatcher);
+        addMatcher(description, "properties are ", propertiesMatcher);
+        addMatcher(description, "labels with ", labelsMatcher);
         ;
+    }
+
+    public void addMatcher(Description description, String fieldName, Matcher<?> matcher) {
+        if (!(matcher instanceof IsAnything)) {
+            description.appendText(fieldName).appendDescriptionOf(matcher).appendText(" ");
+        }
     }
 }

--- a/core/client/src/main/java/uk/gov/dwp/queue/triage/core/client/CreateFailedMessageRequest.java
+++ b/core/client/src/main/java/uk/gov/dwp/queue/triage/core/client/CreateFailedMessageRequest.java
@@ -7,7 +7,9 @@ import uk.gov.dwp.queue.triage.id.FailedMessageId;
 import javax.validation.constraints.NotNull;
 import java.time.Instant;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 public class CreateFailedMessageRequest {
 
@@ -25,6 +27,8 @@ public class CreateFailedMessageRequest {
     private final String content;
     @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
     private final Map<String, Object> properties;
+    @NotNull
+    private final Set<String> labels;
 
     CreateFailedMessageRequest(@JsonProperty("failedMessageId") FailedMessageId failedMessageId,
                                @JsonProperty("brokerName") String brokerName,
@@ -32,7 +36,8 @@ public class CreateFailedMessageRequest {
                                @JsonProperty("sentAt") Instant sentAt,
                                @JsonProperty("failedAt") Instant failedAt,
                                @JsonProperty("content") String content,
-                               @JsonProperty("properties") Map<String, Object> properties) {
+                               @JsonProperty("properties") Map<String, Object> properties,
+                               @JsonProperty("labels") Set<String> labels) {
         this.failedMessageId = failedMessageId;
         this.brokerName = brokerName;
         this.destination = destination;
@@ -40,6 +45,7 @@ public class CreateFailedMessageRequest {
         this.failedAt = failedAt;
         this.content = content;
         this.properties = properties;
+        this.labels = labels;
     }
 
     public static CreateFailedMessageRequestBuilder newCreateFailedMessageRequest() {
@@ -74,6 +80,10 @@ public class CreateFailedMessageRequest {
         return properties;
     }
 
+    public Set<String> getLabels() {
+        return labels;
+    }
+
     public static class CreateFailedMessageRequestBuilder {
         private FailedMessageId failedMessageId;
         private String brokerName;
@@ -82,12 +92,13 @@ public class CreateFailedMessageRequest {
         private Instant failedDateTime;
         private String content;
         private Map<String, Object> properties = new HashMap<>();
+        private Set<String> labels= new HashSet<>();
 
         private CreateFailedMessageRequestBuilder() {
         }
 
         public CreateFailedMessageRequest build() {
-            return new CreateFailedMessageRequest(failedMessageId, brokerName, destinationName, sentDateTime, failedDateTime, content, properties);
+            return new CreateFailedMessageRequest(failedMessageId, brokerName, destinationName, sentDateTime, failedDateTime, content, properties, labels);
         }
 
         public CreateFailedMessageRequestBuilder withFailedMessageId(FailedMessageId failedMessageId) {
@@ -127,6 +138,16 @@ public class CreateFailedMessageRequest {
 
         public CreateFailedMessageRequestBuilder withProperty(String key, Object value) {
             this.properties.put(key, value);
+            return this;
+        }
+
+        public CreateFailedMessageRequestBuilder withLabels(Set<String> labels) {
+            this.labels = (labels != null) ? labels : new HashSet<>();
+            return this;
+        }
+
+        public CreateFailedMessageRequestBuilder withLabel(String label) {
+            this.labels.add(label);
             return this;
         }
     }

--- a/core/client/src/main/java/uk/gov/dwp/queue/triage/core/client/FailedMessageResponse.java
+++ b/core/client/src/main/java/uk/gov/dwp/queue/triage/core/client/FailedMessageResponse.java
@@ -5,8 +5,10 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import uk.gov.dwp.queue.triage.id.FailedMessageId;
 
 import java.time.Instant;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.apache.commons.lang3.builder.ToStringBuilder.reflectionToString;
 
@@ -21,6 +23,7 @@ public class FailedMessageResponse {
     private final FailedMessageStatus currentStatus;
     @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
     private final Map<String, Object> properties;
+    private final Set<String> labels;
 
     public FailedMessageResponse(@JsonProperty("failedMessageId") FailedMessageId failedMessageId,
                                  @JsonProperty("broker") String broker,
@@ -29,7 +32,8 @@ public class FailedMessageResponse {
                                  @JsonProperty("failedAt") Instant failedAt,
                                  @JsonProperty("content") String content,
                                  @JsonProperty("currentStatus") FailedMessageStatus currentStatus,
-                                 @JsonProperty("properties") Map<String, Object> properties) {
+                                 @JsonProperty("properties") Map<String, Object> properties,
+                                 @JsonProperty("labels") Set<String> labels) {
         this.failedMessageId = failedMessageId;
         this.broker = broker;
         this.destination = destination;
@@ -38,6 +42,7 @@ public class FailedMessageResponse {
         this.content = content;
         this.currentStatus = currentStatus;
         this.properties = properties;
+        this.labels = labels;
     }
 
     public FailedMessageId getFailedMessageId() {
@@ -76,9 +81,12 @@ public class FailedMessageResponse {
         return (T) properties.get(name);
     }
 
+    public Set<String> getLabels() {
+        return new HashSet<>(labels);
+    }
+
     @Override
     public String toString() {
         return reflectionToString(this);
     }
-
 }

--- a/core/client/src/main/java/uk/gov/dwp/queue/triage/core/client/label/LabelFailedMessageClient.java
+++ b/core/client/src/main/java/uk/gov/dwp/queue/triage/core/client/label/LabelFailedMessageClient.java
@@ -1,0 +1,25 @@
+package uk.gov.dwp.queue.triage.core.client.label;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import uk.gov.dwp.queue.triage.id.FailedMessageId;
+
+import javax.ws.rs.DELETE;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
+@Api(value = "Label")
+@Path("/failed-message/label")
+public interface LabelFailedMessageClient {
+
+    @ApiOperation("Add a label to a FailedMessage")
+    @PUT
+    @Path("/{failedMessageId}/{label}")
+    void addLabel(@PathParam("failedMessageId") FailedMessageId failedMessageId, @PathParam("label") String label);
+
+    @ApiOperation("Remove a label from a FailedMessage")
+    @DELETE
+    @Path("/{failedMessageId}/{label}")
+    void removeLabel(@PathParam("failedMessageId") FailedMessageId failedMessageId, @PathParam("label") String label);
+}

--- a/core/component-test/BUCK
+++ b/core/component-test/BUCK
@@ -37,6 +37,7 @@ java_library(
         '//lib/test:hamcrest-optional',
         '//lib/test:jgiven',
         '//lib/test:jgiven-spring',
+        '//lib/test:junit',
     ],
     visibility = [
         "//core/component-test:test"

--- a/core/component-test/src/main/java/uk/gov/dwp/queue/triage/core/BaseCoreComponentTest.java
+++ b/core/component-test/src/main/java/uk/gov/dwp/queue/triage/core/BaseCoreComponentTest.java
@@ -1,9 +1,14 @@
 package uk.gov.dwp.queue.triage.core;
 
+import com.mongodb.MongoClient;
 import com.tngtech.jgiven.integration.spring.EnableJGiven;
 import com.tngtech.jgiven.integration.spring.SimpleSpringRuleScenarioTest;
+import org.junit.Before;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import uk.gov.dwp.queue.triage.core.dao.mongo.MongoDatabaseCleaner;
+import uk.gov.dwp.queue.triage.core.stub.app.resource.StubMessageClassifierResource;
 
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
@@ -12,4 +17,14 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 @ActiveProfiles(value = "component-test")
 public class BaseCoreComponentTest<STAGE> extends SimpleSpringRuleScenarioTest<STAGE> {
 
+    @Autowired
+    private MongoClient mongoClient;
+    @Autowired
+    private StubMessageClassifierResource stubMessageClassifierResource;
+
+    @Before
+    public void cleanDatabases() {
+        new MongoDatabaseCleaner(mongoClient).cleanDatabase("queue-triage");
+        stubMessageClassifierResource.clear();
+    }
 }

--- a/core/component-test/src/main/java/uk/gov/dwp/queue/triage/core/JmsStage.java
+++ b/core/component-test/src/main/java/uk/gov/dwp/queue/triage/core/JmsStage.java
@@ -1,8 +1,6 @@
 package uk.gov.dwp.queue.triage.core;
 
-import com.mongodb.MongoClient;
 import com.tngtech.jgiven.Stage;
-import com.tngtech.jgiven.annotation.BeforeScenario;
 import com.tngtech.jgiven.integration.spring.JGivenStage;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,7 +8,6 @@ import org.springframework.jms.core.JmsTemplate;
 import uk.gov.dwp.queue.triage.core.classification.MessageClassifier;
 import uk.gov.dwp.queue.triage.core.classification.action.FailedMessageAction;
 import uk.gov.dwp.queue.triage.core.classification.predicate.ContentEqualToPredicate;
-import uk.gov.dwp.queue.triage.core.dao.mongo.MongoDatabaseCleaner;
 import uk.gov.dwp.queue.triage.core.stub.app.resource.StubMessageClassifierResource;
 
 import static org.slf4j.LoggerFactory.getLogger;
@@ -22,15 +19,7 @@ public class JmsStage extends Stage<JmsStage> {
     @Autowired
     private JmsTemplate dummyAppJmsTemplate;
     @Autowired
-    private MongoClient mongoClient;
-    @Autowired
     private StubMessageClassifierResource stubMessageClassifierResource;
-
-    @BeforeScenario
-    public void cleanDatabases() {
-        new MongoDatabaseCleaner(mongoClient).cleanDatabase("queue-triage");
-        stubMessageClassifierResource.clear();
-    }
 
     public JmsStage aMessageWithContent$WillDeadLetter(String content) {
         addMessageClassifierWithContent(

--- a/core/component-test/src/main/java/uk/gov/dwp/queue/triage/core/classification/MessageClassificationGivenStage.java
+++ b/core/component-test/src/main/java/uk/gov/dwp/queue/triage/core/classification/MessageClassificationGivenStage.java
@@ -6,6 +6,7 @@ import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.HttpEntity;
 import uk.gov.dwp.queue.triage.core.classification.MessageClassifier.MessageClassifierBuilder;
 import uk.gov.dwp.queue.triage.core.classification.action.DeleteMessageAction;
+import uk.gov.dwp.queue.triage.core.classification.action.LabelMessageAction;
 import uk.gov.dwp.queue.triage.core.classification.predicate.BrokerEqualsPredicate;
 import uk.gov.dwp.queue.triage.core.classification.predicate.ContentEqualToPredicate;
 import uk.gov.dwp.queue.triage.core.classification.predicate.DestinationEqualsPredicate;
@@ -33,6 +34,15 @@ public class MessageClassificationGivenStage extends GivenStage<MessageClassific
         testRestTemplate.postForLocation(
                 "/core/message-classification",
                 predicateBuilder.then(new DeleteMessageAction(null))
+        );
+        return this;
+    }
+
+    public MessageClassificationGivenStage aMessageClassifierExistsToLabelAnyMessage$FromBroker$(String label, String broker) {
+        MessageClassifierBuilder predicateBuilder = MessageClassifier.when(new BrokerEqualsPredicate(broker));
+        testRestTemplate.postForLocation(
+                "/core/message-classification",
+                predicateBuilder.then(new LabelMessageAction(label, null))
         );
         return this;
     }

--- a/core/component-test/src/main/java/uk/gov/dwp/queue/triage/core/label/AddLabelWhenStage.java
+++ b/core/component-test/src/main/java/uk/gov/dwp/queue/triage/core/label/AddLabelWhenStage.java
@@ -1,0 +1,33 @@
+package uk.gov.dwp.queue.triage.core.label;
+
+
+import com.google.common.collect.ImmutableMap;
+import com.tngtech.jgiven.integration.spring.JGivenStage;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import uk.gov.dwp.queue.triage.id.FailedMessageId;
+import uk.gov.dwp.queue.triage.jgiven.WhenStage;
+
+@JGivenStage
+public class AddLabelWhenStage extends WhenStage<AddLabelWhenStage> {
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    public AddLabelWhenStage $IsAddedAsALabelToFailedMessage$(String label, FailedMessageId failedMessageId) {
+        restTemplate.put(
+                "/core/failed-message/label/{failedMessageId}/{label}",
+                null,
+                ImmutableMap.of("failedMessageId", failedMessageId, "label", label)
+        );
+        return this;
+    }
+
+    public AddLabelWhenStage theLabel$IsRemovedFromFAiledMessage$(String label, FailedMessageId failedMessageId) {
+        restTemplate.delete(
+                "/core/failed-message/label/{failedMessageId}/{label}",
+                ImmutableMap.of("failedMessageId", failedMessageId, "label", label)
+        );
+        return this;
+    }
+}

--- a/core/component-test/src/main/java/uk/gov/dwp/queue/triage/core/search/SearchFailedMessageStage.java
+++ b/core/component-test/src/main/java/uk/gov/dwp/queue/triage/core/search/SearchFailedMessageStage.java
@@ -1,8 +1,6 @@
 package uk.gov.dwp.queue.triage.core.search;
 
-import com.mongodb.MongoClient;
 import com.tngtech.jgiven.Stage;
-import com.tngtech.jgiven.annotation.BeforeScenario;
 import com.tngtech.jgiven.annotation.ExpectedScenarioState;
 import com.tngtech.jgiven.annotation.Format;
 import com.tngtech.jgiven.integration.spring.JGivenStage;
@@ -16,7 +14,6 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageRequest.SearchFailedMessageRequestBuilder;
 import uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageResponse;
-import uk.gov.dwp.queue.triage.core.dao.mongo.MongoDatabaseCleaner;
 import uk.gov.dwp.queue.triage.jgiven.ReflectionArgumentFormatter;
 
 import javax.ws.rs.core.Response.Status;
@@ -32,16 +29,9 @@ public class SearchFailedMessageStage extends Stage<SearchFailedMessageStage> {
 
     @Autowired
     private TestRestTemplate testRestTemplate;
-    @Autowired
-    private MongoClient mongoClient;
 
     @ExpectedScenarioState
     private ResponseEntity<Collection<SearchFailedMessageResponse>> searchResponse;
-
-    @BeforeScenario
-    public void cleanDatabases() {
-        new MongoDatabaseCleaner(mongoClient).cleanDatabase("queue-triage");
-    }
 
     public SearchFailedMessageStage aSearchIsRequested(@Format(value = ReflectionArgumentFormatter.class, args = {"broker", "destination"}) SearchFailedMessageRequestBuilder requestBuilder) {
         searchResponse = testRestTemplate.exchange(

--- a/core/component-test/src/test/java/uk/gov/dwp/queue/triage/core/label/ManageLabelsComponentTest.java
+++ b/core/component-test/src/test/java/uk/gov/dwp/queue/triage/core/label/ManageLabelsComponentTest.java
@@ -1,0 +1,48 @@
+package uk.gov.dwp.queue.triage.core.label;
+
+import com.tngtech.jgiven.annotation.ScenarioStage;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import uk.gov.dwp.queue.triage.core.BaseCoreComponentTest;
+import uk.gov.dwp.queue.triage.core.FailedMessageResourceStage;
+import uk.gov.dwp.queue.triage.core.client.CreateFailedMessageRequest;
+import uk.gov.dwp.queue.triage.core.domain.FailedMessageResponseMatcher;
+import uk.gov.dwp.queue.triage.id.FailedMessageId;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static uk.gov.dwp.queue.triage.core.client.CreateFailedMessageRequest.newCreateFailedMessageRequest;
+import static uk.gov.dwp.queue.triage.core.domain.FailedMessageResponseMatcher.aFailedMessage;
+import static uk.gov.dwp.queue.triage.id.FailedMessageId.newFailedMessageId;
+
+public class ManageLabelsComponentTest extends BaseCoreComponentTest<FailedMessageResourceStage> {
+
+    private final FailedMessageId failedMessageId = newFailedMessageId();
+
+    @ScenarioStage
+    private AddLabelWhenStage addLabelWhenStage;
+
+    @Test
+    public void addLabelToFailedMessage() {
+        given().aFailedMessage(newCreateFailedMessageRequest().withFailedMessageId(failedMessageId).withBrokerName("some-broker")).exists();
+
+        addLabelWhenStage.when().$IsAddedAsALabelToFailedMessage$("foo", failedMessageId);
+        addLabelWhenStage.when().$IsAddedAsALabelToFailedMessage$("bar", failedMessageId);
+
+        then().aFailedMessageWithId$Has(failedMessageId, aFailedMessage().withLabels(containsInAnyOrder("foo", "bar")));
+
+    }
+
+    @Test
+    public void removeLabelFromFailedMessage() {
+        given().aFailedMessage(newCreateFailedMessageRequest()
+                .withFailedMessageId(failedMessageId).withBrokerName("some-broker")
+                .withLabel("foo").withLabel("bar")).exists();
+
+        addLabelWhenStage.when().theLabel$IsRemovedFromFAiledMessage$("bar", failedMessageId);
+
+        then().aFailedMessageWithId$Has(failedMessageId, aFailedMessage().withLabels(contains("foo")));
+    }
+
+
+}

--- a/core/dao-mongo/src/main/java/uk/gov/dwp/queue/triage/core/dao/mongo/DBObjectConverter.java
+++ b/core/dao-mongo/src/main/java/uk/gov/dwp/queue/triage/core/dao/mongo/DBObjectConverter.java
@@ -1,7 +1,17 @@
 package uk.gov.dwp.queue.triage.core.dao.mongo;
 
+import com.mongodb.BasicDBList;
 import com.mongodb.DBObject;
 import uk.gov.dwp.queue.triage.core.dao.ObjectConverter;
 
+import java.util.Collection;
+
 public interface DBObjectConverter<T> extends ObjectConverter<T, DBObject> {
+
+    static BasicDBList toBasicDBList(Collection<?> collection) {
+        BasicDBList basicDBList = new BasicDBList();
+        basicDBList.addAll(collection);
+        return basicDBList;
+    }
+
 }

--- a/core/dao-mongo/src/main/java/uk/gov/dwp/queue/triage/core/dao/mongo/DestinationDBObjectConverter.java
+++ b/core/dao-mongo/src/main/java/uk/gov/dwp/queue/triage/core/dao/mongo/DestinationDBObjectConverter.java
@@ -13,7 +13,7 @@ public class DestinationDBObjectConverter implements DBObjectConverter<Destinati
 
     @Override
     public Destination convertToObject(DBObject dbObject) {
-        return new Destination((String)dbObject.get(BROKER_NAME), Optional.of((String)dbObject.get(NAME)));
+        return new Destination((String)dbObject.get(BROKER_NAME), Optional.ofNullable((String)dbObject.get(NAME)));
     }
 
     @Override

--- a/core/dao-mongo/src/main/java/uk/gov/dwp/queue/triage/core/dao/mongo/FailedMessageConverter.java
+++ b/core/dao-mongo/src/main/java/uk/gov/dwp/queue/triage/core/dao/mongo/FailedMessageConverter.java
@@ -12,8 +12,10 @@ import uk.gov.dwp.queue.triage.id.FailedMessageId;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static uk.gov.dwp.queue.triage.core.domain.FailedMessageBuilder.newFailedMessage;
 import static uk.gov.dwp.queue.triage.id.FailedMessageId.fromString;
@@ -26,6 +28,7 @@ public class FailedMessageConverter implements DBObjectWithIdConverter<FailedMes
     public static final String CONTENT = "content";
     public static final String PROPERTIES = "properties";
     public static final String STATUS_HISTORY = "statusHistory";
+    public static final String LABELS = "labels";
 
     private final DBObjectConverter<Destination> destinationDBObjectMapper;
     private final DBObjectConverter<FailedMessageStatus> failedMessageStatusDBObjectMapper;
@@ -53,6 +56,7 @@ public class FailedMessageConverter implements DBObjectWithIdConverter<FailedMes
                 .withContent(getContent(basicDBObject))
                 .withFailedMessageStatus(getFailedMessageStatus(basicDBObject))
                 .withProperties(propertiesMongoMapper.convertToObject(basicDBObject.getString(PROPERTIES)))
+                .withLabels(getLabels(basicDBObject))
                 .build();
     }
 
@@ -90,6 +94,10 @@ public class FailedMessageConverter implements DBObjectWithIdConverter<FailedMes
         return (Instant) basicDBObject.get(SENT_DATE_TIME);
     }
 
+    private Set<String> getLabels(BasicDBObject basicDBObject) {
+        return new HashSet<>((List<String>)basicDBObject.get(LABELS));
+    }
+
     @Override
     public BasicDBObject convertFromObject(FailedMessage item) {
         return createId(item.getFailedMessageId())
@@ -99,6 +107,7 @@ public class FailedMessageConverter implements DBObjectWithIdConverter<FailedMes
                 .append(CONTENT, item.getContent())
                 .append(PROPERTIES, propertiesMongoMapper.convertFromObject(item.getProperties()))
                 .append(STATUS_HISTORY, Collections.singletonList(failedMessageStatusDBObjectMapper.convertFromObject(item.getFailedMessageStatus())))
+                .append(LABELS, DBObjectConverter.toBasicDBList(item.getLabels()))
                 ;
     }
 

--- a/core/dao-mongo/src/main/java/uk/gov/dwp/queue/triage/core/dao/mongo/FailedMessageMongoDao.java
+++ b/core/dao-mongo/src/main/java/uk/gov/dwp/queue/triage/core/dao/mongo/FailedMessageMongoDao.java
@@ -4,6 +4,7 @@ import com.mongodb.BasicDBList;
 import com.mongodb.BasicDBObject;
 import com.mongodb.DBCollection;
 import com.mongodb.DBObject;
+import com.mongodb.QueryOperators;
 import com.mongodb.operation.OrderBy;
 import uk.gov.dwp.queue.triage.core.dao.FailedMessageDao;
 import uk.gov.dwp.queue.triage.core.domain.FailedMessage;
@@ -16,6 +17,7 @@ import java.util.stream.Collectors;
 import static java.util.Collections.singletonList;
 import static uk.gov.dwp.queue.triage.core.dao.mongo.DestinationDBObjectConverter.BROKER_NAME;
 import static uk.gov.dwp.queue.triage.core.dao.mongo.FailedMessageConverter.DESTINATION;
+import static uk.gov.dwp.queue.triage.core.dao.mongo.FailedMessageConverter.LABELS;
 import static uk.gov.dwp.queue.triage.core.dao.mongo.FailedMessageConverter.STATUS_HISTORY;
 import static uk.gov.dwp.queue.triage.core.dao.mongo.FailedMessageStatusDBObjectConverter.LAST_MODIFIED_DATE_TIME;
 
@@ -76,5 +78,21 @@ public class FailedMessageMongoDao implements FailedMessageDao {
     @Override
     public int removeFailedMessages() {
         return collection.remove(removeRecordsQueryFactory.create()).getN();
+    }
+
+    @Override
+    public void addLabel(FailedMessageId failedMessageId, String label) {
+        collection.update(
+                failedMessageConverter.createId(failedMessageId),
+                new BasicDBObject("$addToSet", new BasicDBObject(LABELS, label))
+        );
+    }
+
+    @Override
+    public void removeLabel(FailedMessageId failedMessageId, String label) {
+        collection.update(
+                failedMessageConverter.createId(failedMessageId),
+                new BasicDBObject("$pull", new BasicDBObject(LABELS, label))
+        );
     }
 }

--- a/core/dao-mongo/src/test/java/uk/gov/dwp/queue/triage/core/dao/mongo/DestinationDBObjectConverterTest.java
+++ b/core/dao-mongo/src/test/java/uk/gov/dwp/queue/triage/core/dao/mongo/DestinationDBObjectConverterTest.java
@@ -4,7 +4,8 @@ import com.mongodb.DBObject;
 import org.junit.Test;
 import uk.gov.dwp.queue.triage.core.domain.Destination;
 
-import static java.util.Optional.of;
+import java.util.Optional;
+
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static uk.gov.dwp.queue.triage.core.domain.DestinationMatcher.aDestination;
@@ -14,9 +15,16 @@ public class DestinationDBObjectConverterTest {
     private final DestinationDBObjectConverter underTest = new DestinationDBObjectConverter();
 
     @Test
-    public void testConvertQueueToDBObjectAndBack() throws Exception {
-        DBObject basicDBObject = underTest.convertFromObject(new Destination("broker.name", of("queue.name")));
+    public void convertDestinationToDBObjectAndBack() throws Exception {
+        DBObject basicDBObject = underTest.convertFromObject(new Destination("broker.name", Optional.of("queue.name")));
 
         assertThat(underTest.convertToObject(basicDBObject), is(aDestination().withBrokerName("broker.name").withName("queue.name")));
+    }
+
+    @Test
+    public void convertDestinationWithMissingNameToDBObjectAndBack() throws Exception {
+        DBObject basicDBObject = underTest.convertFromObject(new Destination("broker.name", Optional.empty()));
+
+        assertThat(underTest.convertToObject(basicDBObject), is(aDestination().withBrokerName("broker.name").withNoName()));
     }
 }

--- a/core/dao-mongo/src/test/java/uk/gov/dwp/queue/triage/core/dao/mongo/FailedMessageMongoDaoTest.java
+++ b/core/dao-mongo/src/test/java/uk/gov/dwp/queue/triage/core/dao/mongo/FailedMessageMongoDaoTest.java
@@ -22,6 +22,8 @@ import static java.util.Collections.emptyMap;
 import static java.util.Optional.of;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.emptyIterable;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
@@ -56,7 +58,7 @@ public class FailedMessageMongoDaoTest extends AbstractMongoDaoTest {
     }
 
     @Test
-    public void saveMessageWithEmptyProperties() throws Exception {
+    public void saveMessageWithEmptyPropertiesAndNoLabels() throws Exception {
         failedMessageBuilder.withProperties(emptyMap());
 
         underTest.insert(failedMessageBuilder.build());
@@ -66,11 +68,12 @@ public class FailedMessageMongoDaoTest extends AbstractMongoDaoTest {
                 .withContent(equalTo("Hello"))
                 .withProperties(equalTo(emptyMap()))
                 .withFailedMessageStatus(FailedMessageStatusMatcher.equalTo(FAILED))
+                .withLabels(emptyIterable())
         ));
     }
 
     @Test
-    public void saveMessageWithProperties() throws Exception {
+    public void saveMessageWithPropertiesAndLabels() throws Exception {
         HashMapBuilder<String, Object> hashMapBuilder = newHashMap(String.class, Object.class)
                 .put("string", "Builder")
                 .put("localDateTime", LocalDateTime.now())
@@ -81,7 +84,10 @@ public class FailedMessageMongoDaoTest extends AbstractMongoDaoTest {
 
         HashMap<String, Object> properties = hashMapBuilder.build();
         properties.put("properties", hashMapBuilder.build());
-        failedMessageBuilder.withProperties(properties);
+        failedMessageBuilder
+                .withProperties(properties)
+                .withLabel("foo")
+                .withLabel("bar");
 
         underTest.insert(failedMessageBuilder.build());
 
@@ -90,6 +96,7 @@ public class FailedMessageMongoDaoTest extends AbstractMongoDaoTest {
                 .withContent(equalTo("Hello"))
                 .withProperties(equalTo(properties))
                 .withFailedMessageStatus(FailedMessageStatusMatcher.equalTo(FAILED))
+                .withLabels(containsInAnyOrder("foo", "bar"))
         ));
     }
 

--- a/core/dao-mongo/src/test/java/uk/gov/dwp/queue/triage/core/dao/mongo/FailedMessageMongoDaoTest.java
+++ b/core/dao-mongo/src/test/java/uk/gov/dwp/queue/triage/core/dao/mongo/FailedMessageMongoDaoTest.java
@@ -182,6 +182,14 @@ public class FailedMessageMongoDaoTest extends AbstractMongoDaoTest {
     }
 
     @Test
+    public void addLabelToAFailedMessageThatDoesNotExist() {
+        underTest.addLabel(failedMessageId, "foo");
+
+        //TODO: What should be the behaviour (no current use case)? Throw an Exception?  Return a Boolean?
+        assertThat(collection.count(), is(0L));
+    }
+
+    @Test
     public void removeLabelFromAFailedMessage() {
         underTest.insert(failedMessageBuilder.withLabel("foo").build());
 
@@ -191,12 +199,20 @@ public class FailedMessageMongoDaoTest extends AbstractMongoDaoTest {
     }
 
     @Test
-    public void removeLabelThatDoesNotExistIsSuccessful() {
+    public void removeLabelThatDoesNotExistFromAFailedMessageIsSuccessful() {
         underTest.insert(failedMessageBuilder.withLabel("foo").build());
 
         underTest.removeLabel(failedMessageId, "bar");
 
         assertThat(underTest.findById(failedMessageId), aFailedMessage().withLabels(contains("foo")));
+    }
+
+    @Test
+    public void removeLabelForAFailedMessageThatDoesNotExist() {
+        underTest.removeLabel(failedMessageId, "bar");
+
+        //TODO: What should be the behaviour (no current use case)? Throw an Exception?  Return a Boolean?
+        assertThat(collection.count(), is(0L));
     }
 
     public FailedMessage newFailedMessageWithStatus(FailedMessageStatus.Status status, Instant instant) {

--- a/core/dao/src/main/java/uk/gov/dwp/queue/triage/core/dao/FailedMessageDao.java
+++ b/core/dao/src/main/java/uk/gov/dwp/queue/triage/core/dao/FailedMessageDao.java
@@ -19,4 +19,8 @@ public interface FailedMessageDao {
     List<FailedMessageStatus> getStatusHistory(FailedMessageId failedMessageId);
 
     int removeFailedMessages();
+
+    void addLabel(FailedMessageId failedMessageId, String label);
+
+    void removeLabel(FailedMessageId failedMessageId, String label);
 }

--- a/core/domain-test-support/BUCK
+++ b/core/domain-test-support/BUCK
@@ -11,6 +11,7 @@ java_library(
     visibility = [
         "//core/activemq:test",
         "//core/dao-mongo:test",
+        "//core/domain:test",
         "//core/jms:test",
         "//core/server:test",
         "//core/service:test",

--- a/core/domain-test-support/src/main/java/uk/gov/dwp/queue/triage/core/domain/FailedMessageMatcher.java
+++ b/core/domain-test-support/src/main/java/uk/gov/dwp/queue/triage/core/domain/FailedMessageMatcher.java
@@ -8,6 +8,7 @@ import uk.gov.dwp.queue.triage.id.FailedMessageId;
 
 import java.time.Instant;
 import java.util.Map;
+import java.util.Set;
 
 import static org.hamcrest.Matchers.equalTo;
 
@@ -20,6 +21,7 @@ public class FailedMessageMatcher extends TypeSafeMatcher<FailedMessage> {
     private Matcher<Instant> failedAtMatcher = new IsAnything<>();
     private Matcher<Map<? extends String, ? extends Object>> propertiesMatcher = new IsAnything<>();
     private Matcher<FailedMessageStatus> failedMessageStatusMatcher = new IsAnything<>();
+    private Matcher<Iterable<? extends String>> labelsMatcher = new IsAnything<>();
 
     private FailedMessageMatcher() { }
 
@@ -72,6 +74,11 @@ public class FailedMessageMatcher extends TypeSafeMatcher<FailedMessage> {
         return this;
     }
 
+    public FailedMessageMatcher withLabels(Matcher<Iterable<? extends String>> labelsMatcher) {
+        this.labelsMatcher = labelsMatcher;
+        return this;
+    }
+
     @Override
     protected boolean matchesSafely(FailedMessage item) {
         return failedMessageIdMatcher.matches(item.getFailedMessageId())
@@ -81,6 +88,7 @@ public class FailedMessageMatcher extends TypeSafeMatcher<FailedMessage> {
                 && failedAtMatcher.matches(item.getFailedAt())
                 && propertiesMatcher.matches(item.getProperties())
                 && failedMessageStatusMatcher.matches(item.getFailedMessageStatus())
+                && labelsMatcher.matches(item.getLabels())
                 ;
     }
 
@@ -94,6 +102,7 @@ public class FailedMessageMatcher extends TypeSafeMatcher<FailedMessage> {
                 .appendText(" failedAt is ").appendDescriptionOf(failedAtMatcher)
                 .appendText(" properties are ").appendDescriptionOf(propertiesMatcher)
                 .appendText(" status is ").appendDescriptionOf(failedMessageStatusMatcher)
+                .appendText(" labels are ").appendDescriptionOf(labelsMatcher)
         ;
     }
 }

--- a/core/domain/BUCK
+++ b/core/domain/BUCK
@@ -41,6 +41,8 @@ java_test(
     srcs = glob(["src/test/java/**/*.java"]),
     deps = [
         ':queue-triage-core-domain',
+        '//common/id:queue-triage-common-id',
+        '//core/domain-test-support:queue-triage-core-domain-test-support',
         '//core/client:queue-triage-core-client',
         '//lib:guava',
         '//lib/test:common',

--- a/core/domain/src/main/java/uk/gov/dwp/queue/triage/core/domain/FailedMessage.java
+++ b/core/domain/src/main/java/uk/gov/dwp/queue/triage/core/domain/FailedMessage.java
@@ -3,7 +3,9 @@ package uk.gov.dwp.queue.triage.core.domain;
 import uk.gov.dwp.queue.triage.id.FailedMessageId;
 
 import java.time.Instant;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import static org.apache.commons.lang3.builder.ToStringBuilder.reflectionToString;
 
@@ -16,6 +18,7 @@ public class FailedMessage {
     private final String content;
     private final Map<String, Object> properties;
     private final FailedMessageStatus failedMessageStatus;
+    private final Set<String> labels;
 
     FailedMessage(FailedMessageId failedMessageId,
                   Destination destination,
@@ -23,7 +26,8 @@ public class FailedMessage {
                   Instant failedAt,
                   String content,
                   Map<String, Object> properties,
-                  FailedMessageStatus failedMessageStatus) {
+                  FailedMessageStatus failedMessageStatus,
+                  Set<String> labels) {
         this.failedMessageId = failedMessageId;
         this.destination = destination;
         this.sentAt = sentAt;
@@ -31,6 +35,7 @@ public class FailedMessage {
         this.content = content;
         this.properties = properties;
         this.failedMessageStatus = failedMessageStatus;
+        this.labels = labels;
     }
 
     public FailedMessageId getFailedMessageId() {
@@ -59,6 +64,10 @@ public class FailedMessage {
 
     public <T> T getProperty(String name) {
         return (T)properties.get(name);
+    }
+
+    public Set<String> getLabels() {
+        return new HashSet<>(labels);
     }
 
     @Override

--- a/core/domain/src/main/java/uk/gov/dwp/queue/triage/core/domain/FailedMessageBuilder.java
+++ b/core/domain/src/main/java/uk/gov/dwp/queue/triage/core/domain/FailedMessageBuilder.java
@@ -5,7 +5,9 @@ import uk.gov.dwp.queue.triage.id.FailedMessageId;
 
 import java.time.Instant;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 public class FailedMessageBuilder {
 
@@ -16,6 +18,7 @@ public class FailedMessageBuilder {
     private String content;
     private Map<String, Object> properties = new HashMap<>();
     private FailedMessageStatus failedMessageStatus;
+    private Set<String> labels = new HashSet<>();
 
     private FailedMessageBuilder() {
     }
@@ -33,11 +36,12 @@ public class FailedMessageBuilder {
                 .withFailedDateTime(failedMessage.getFailedAt())
                 .withContent(failedMessage.getContent())
                 .withProperties(failedMessage.getProperties())
-                .withFailedMessageStatus(failedMessage.getFailedMessageStatus());
+                .withFailedMessageStatus(failedMessage.getFailedMessageStatus())
+                .withLabels(failedMessage.getLabels());
     }
 
     public FailedMessage build() {
-        return new FailedMessage(failedMessageId, destination, sentDateTime, failedDateTime, content, properties, failedMessageStatus);
+        return new FailedMessage(failedMessageId, destination, sentDateTime, failedDateTime, content, properties, failedMessageStatus, labels);
     }
 
     public FailedMessageBuilder withNewFailedMessageId() {
@@ -87,6 +91,16 @@ public class FailedMessageBuilder {
 
     public FailedMessageBuilder withFailedMessageStatus(FailedMessageStatus failedMessageStatus) {
         this.failedMessageStatus = failedMessageStatus;
+        return this;
+    }
+
+    public FailedMessageBuilder withLabels(Set<String> labels) {
+        this.labels = (labels != null) ? labels : new HashSet<>();
+        return this;
+    }
+
+    public FailedMessageBuilder withLabel(String label) {
+        labels.add(label);
         return this;
     }
 }

--- a/core/domain/src/test/java/uk/gov/dwp/queue/triage/core/domain/FailedMessageBuilderTest.java
+++ b/core/domain/src/test/java/uk/gov/dwp/queue/triage/core/domain/FailedMessageBuilderTest.java
@@ -1,0 +1,63 @@
+package uk.gov.dwp.queue.triage.core.domain;
+
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import uk.gov.dwp.queue.triage.id.FailedMessageId;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static uk.gov.dwp.queue.triage.core.domain.FailedMessageStatus.Status.FAILED;
+
+public class FailedMessageBuilderTest {
+
+    private static final String CONTENT = "Foo";
+    private static final String BROKER_NAME = "broker";
+    private static final String DESTINATION_NAME = "destination";
+    private static final FailedMessageId FAILED_MESSAGE_ID = FailedMessageId.newFailedMessageId();
+    private static final Instant NOW = Instant.now();
+    private static final Instant FAILED_DATE_TIME = NOW.plusSeconds(1);
+    private static final Instant SEND_DATE_TIME = NOW.minusSeconds(1);
+
+    private FailedMessageBuilder underTest = FailedMessageBuilder.newFailedMessage()
+            .withContent(CONTENT)
+            .withDestination(new Destination(BROKER_NAME, Optional.of(DESTINATION_NAME)))
+            .withFailedDateTime(FAILED_DATE_TIME)
+            .withFailedMessageId(FAILED_MESSAGE_ID)
+            .withFailedMessageStatus(FAILED)
+            .withSentDateTime(SEND_DATE_TIME);
+
+    @Test
+    public void addSingleLabelAndPropertyToBuilder() throws Exception {
+        assertThat(
+                underTest.withLabel("foo").withProperty("key", "value").build(),
+                is(aFailedMessage()
+                        .withLabels(Matchers.contains("foo"))
+                        .withProperties(Matchers.hasEntry("key", "value"))
+        ));
+    }
+
+    @Test
+    public void createANewFailedMessageWithNoLabelsOrProperties() throws Exception {
+        assertThat(
+                underTest.build(),
+                is(aFailedMessage()
+                        .withLabels(is(Collections.emptySet()))
+                        .withProperties(is(Collections.emptyMap()))
+        ));
+    }
+
+    private FailedMessageMatcher aFailedMessage() {
+        return FailedMessageMatcher.aFailedMessage()
+                .withContent(equalTo(CONTENT))
+                .withDestination(DestinationMatcher.aDestination().withBrokerName(BROKER_NAME).withName(DESTINATION_NAME))
+                .withFailedAt(FAILED_DATE_TIME)
+                .withFailedMessageId(equalTo(FAILED_MESSAGE_ID))
+                .withFailedMessageStatus(FailedMessageStatusMatcher.equalTo(FAILED))
+                .withSentAt(SEND_DATE_TIME);
+    }
+}

--- a/core/message-classification/src/main/java/uk/gov/dwp/queue/triage/core/classification/action/LabelMessageAction.java
+++ b/core/message-classification/src/main/java/uk/gov/dwp/queue/triage/core/classification/action/LabelMessageAction.java
@@ -1,0 +1,28 @@
+package uk.gov.dwp.queue.triage.core.classification.action;
+
+import com.fasterxml.jackson.annotation.JacksonInject;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.dwp.queue.triage.core.domain.FailedMessage;
+import uk.gov.dwp.queue.triage.core.service.FailedMessageLabelService;
+
+public class LabelMessageAction implements FailedMessageAction {
+
+    private final String label;
+    private final FailedMessageLabelService failedMessageLabelService;
+
+    public LabelMessageAction(@JsonProperty("label") String label,
+                              @JacksonInject FailedMessageLabelService failedMessageLabelService) {
+        this.label = label;
+        this.failedMessageLabelService = failedMessageLabelService;
+    }
+
+    @Override
+    public void accept(FailedMessage failedMessage) {
+        failedMessageLabelService.addLabel(failedMessage.getFailedMessageId(), label);
+    }
+
+    @JsonProperty
+    public String getLabel() {
+        return label;
+    }
+}

--- a/core/message-classification/src/test/java/uk/gov/dwp/queue/triage/core/classification/action/LabelMessageActionTest.java
+++ b/core/message-classification/src/test/java/uk/gov/dwp/queue/triage/core/classification/action/LabelMessageActionTest.java
@@ -1,0 +1,44 @@
+package uk.gov.dwp.queue.triage.core.classification.action;
+
+import com.fasterxml.jackson.databind.InjectableValues;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.dwp.queue.triage.core.domain.FailedMessage;
+import uk.gov.dwp.queue.triage.core.service.FailedMessageLabelService;
+import uk.gov.dwp.queue.triage.id.FailedMessageId;
+import uk.gov.dwp.queue.triage.jackson.configuration.JacksonConfiguration;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class LabelMessageActionTest {
+
+    private static final FailedMessageId FAILED_MESSAGE_ID = FailedMessageId.newFailedMessageId();
+    private final ObjectMapper objectMapper = new JacksonConfiguration().objectMapper();
+
+    private final FailedMessageLabelService failedMessageLabelService = mock(FailedMessageLabelService.class);
+    private final FailedMessage failedMessage = mock(FailedMessage.class);
+
+    @Before
+    public void setup() {
+        objectMapper.setInjectableValues(
+                new InjectableValues.Std()
+                        .addValue(FailedMessageLabelService.class, failedMessageLabelService)
+        );
+    }
+
+    @Test
+    public void canSerialiseAndDeserialiseAction() throws Exception {
+        LabelMessageAction underTest = objectMapper.readValue(
+                objectMapper.writeValueAsString(new LabelMessageAction("foo", failedMessageLabelService)),
+                LabelMessageAction.class
+        );
+        when(failedMessage.getFailedMessageId()).thenReturn(FAILED_MESSAGE_ID);
+
+        underTest.accept(failedMessage);
+
+        verify(failedMessageLabelService).addLabel(FAILED_MESSAGE_ID, "foo");
+    }
+}

--- a/core/server/src/main/java/uk/gov/dwp/queue/triage/core/configuration/FailedMessageResourceConfiguration.java
+++ b/core/server/src/main/java/uk/gov/dwp/queue/triage/core/configuration/FailedMessageResourceConfiguration.java
@@ -10,11 +10,13 @@ import uk.gov.dwp.queue.triage.core.dao.mongo.configuration.MongoDaoConfig;
 import uk.gov.dwp.queue.triage.core.domain.FailedMessageStatusAdapter;
 import uk.gov.dwp.queue.triage.core.resource.create.CreateFailedMessageResource;
 import uk.gov.dwp.queue.triage.core.resource.create.FailedMessageFactory;
+import uk.gov.dwp.queue.triage.core.resource.label.LabelFailedMessageResource;
 import uk.gov.dwp.queue.triage.core.resource.resend.ResendFailedMessageResource;
 import uk.gov.dwp.queue.triage.core.resource.search.FailedMessageResponseFactory;
 import uk.gov.dwp.queue.triage.core.resource.search.FailedMessageSearchResource;
 import uk.gov.dwp.queue.triage.core.search.FailedMessageSearchService;
 import uk.gov.dwp.queue.triage.core.search.SearchFailedMessageResponseAdapter;
+import uk.gov.dwp.queue.triage.core.service.FailedMessageLabelService;
 import uk.gov.dwp.queue.triage.core.service.FailedMessageService;
 
 import java.time.Clock;
@@ -50,5 +52,13 @@ public class FailedMessageResourceConfiguration {
         return resourceRegistry.add(new ResendFailedMessageResource(
                 failedMessageService,
                 Clock.systemUTC()));
+    }
+
+    @Bean
+    public LabelFailedMessageResource labelFailedMessageResource(ResourceRegistry resourceRegistry,
+                                                                 FailedMessageLabelService failedMessageLabelService) {
+        return resourceRegistry.add(new LabelFailedMessageResource(
+                failedMessageLabelService
+        ));
     }
 }

--- a/core/server/src/main/java/uk/gov/dwp/queue/triage/core/configuration/FailedMessageServiceConfiguration.java
+++ b/core/server/src/main/java/uk/gov/dwp/queue/triage/core/configuration/FailedMessageServiceConfiguration.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.databind.InjectableValues;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import uk.gov.dwp.queue.triage.core.dao.FailedMessageDao;
+import uk.gov.dwp.queue.triage.core.domain.FailedMessage;
+import uk.gov.dwp.queue.triage.core.service.FailedMessageLabelService;
 import uk.gov.dwp.queue.triage.core.service.FailedMessageService;
 
 @Configuration
@@ -15,5 +17,13 @@ public class FailedMessageServiceConfiguration {
         FailedMessageService failedMessageService = new FailedMessageService(failedMessageDao);
         jacksonInjectableValues.addValue(FailedMessageService.class, failedMessageService);
         return failedMessageService;
+    }
+
+    @Bean
+    public FailedMessageLabelService failedMessageLabelService(FailedMessageDao failedMessageDao,
+                                                               InjectableValues.Std jacksonInjectableValues) {
+        FailedMessageLabelService failedMessageLabelService = new FailedMessageLabelService(failedMessageDao);
+        jacksonInjectableValues.addValue(FailedMessageLabelService.class, failedMessageLabelService);
+        return failedMessageLabelService;
     }
 }

--- a/core/server/src/main/java/uk/gov/dwp/queue/triage/core/resource/create/FailedMessageFactory.java
+++ b/core/server/src/main/java/uk/gov/dwp/queue/triage/core/resource/create/FailedMessageFactory.java
@@ -17,6 +17,7 @@ public class FailedMessageFactory {
                 .withFailedDateTime(request.getFailedAt())
                 .withProperties(request.getProperties())
                 .withSentDateTime(request.getSentAt())
+                .withLabels(request.getLabels())
                 .build();
     }
 }

--- a/core/server/src/main/java/uk/gov/dwp/queue/triage/core/resource/label/LabelFailedMessageResource.java
+++ b/core/server/src/main/java/uk/gov/dwp/queue/triage/core/resource/label/LabelFailedMessageResource.java
@@ -1,0 +1,24 @@
+package uk.gov.dwp.queue.triage.core.resource.label;
+
+import uk.gov.dwp.queue.triage.core.client.label.LabelFailedMessageClient;
+import uk.gov.dwp.queue.triage.core.service.FailedMessageLabelService;
+import uk.gov.dwp.queue.triage.id.FailedMessageId;
+
+public class LabelFailedMessageResource implements LabelFailedMessageClient {
+
+    private final FailedMessageLabelService failedMessageLabelService;
+
+    public LabelFailedMessageResource(FailedMessageLabelService failedMessageLabelService) {
+        this.failedMessageLabelService = failedMessageLabelService;
+    }
+
+    @Override
+    public void addLabel(FailedMessageId failedMessageId, String label) {
+        failedMessageLabelService.addLabel(failedMessageId, label);
+    }
+
+    @Override
+    public void removeLabel(FailedMessageId failedMessageId, String label) {
+        failedMessageLabelService.removeLabel(failedMessageId, label);
+    }
+}

--- a/core/server/src/main/java/uk/gov/dwp/queue/triage/core/resource/search/FailedMessageResponseFactory.java
+++ b/core/server/src/main/java/uk/gov/dwp/queue/triage/core/resource/search/FailedMessageResponseFactory.java
@@ -21,7 +21,7 @@ public class FailedMessageResponseFactory {
                 failedMessage.getFailedAt(),
                 failedMessage.getContent(),
                 failedMessageStatusAdapter.toFailedMessageStatus(failedMessage.getFailedMessageStatus().getStatus()),
-                failedMessage.getProperties()
-        );
+                failedMessage.getProperties(),
+                failedMessage.getLabels());
     }
 }

--- a/core/service/src/main/java/uk/gov/dwp/queue/triage/core/service/FailedMessageLabelService.java
+++ b/core/service/src/main/java/uk/gov/dwp/queue/triage/core/service/FailedMessageLabelService.java
@@ -1,0 +1,27 @@
+package uk.gov.dwp.queue.triage.core.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.dwp.queue.triage.core.dao.FailedMessageDao;
+import uk.gov.dwp.queue.triage.id.FailedMessageId;
+
+public class FailedMessageLabelService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FailedMessageLabelService.class);
+
+    private final FailedMessageDao failedMessageDao;
+
+    public FailedMessageLabelService(FailedMessageDao failedMessageDao) {
+        this.failedMessageDao = failedMessageDao;
+    }
+
+    public void addLabel(FailedMessageId failedMessageId, String label) {
+        failedMessageDao.addLabel(failedMessageId, label);
+        LOGGER.debug("Added label '{}' to FailedMessage: {}", label, failedMessageId);
+    }
+
+    public void removeLabel(FailedMessageId failedMessageId, String label) {
+        failedMessageDao.removeLabel(failedMessageId, label);
+        LOGGER.debug("Removed label '{}' from FailedMessage: {}", label, failedMessageId);
+    }
+}

--- a/core/service/src/test/java/uk/gov/dwp/queue/triage/core/service/FailedMessageLabelServiceTest.java
+++ b/core/service/src/test/java/uk/gov/dwp/queue/triage/core/service/FailedMessageLabelServiceTest.java
@@ -1,0 +1,30 @@
+package uk.gov.dwp.queue.triage.core.service;
+
+import org.junit.Test;
+import uk.gov.dwp.queue.triage.core.dao.FailedMessageDao;
+import uk.gov.dwp.queue.triage.id.FailedMessageId;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class FailedMessageLabelServiceTest {
+
+    private static final String LABEL = "foo";
+    private static final FailedMessageId FAILED_MESSAGE_ID = FailedMessageId.newFailedMessageId();
+    private final FailedMessageDao failedMessageDao = mock(FailedMessageDao.class);
+    private final FailedMessageLabelService underTest = new FailedMessageLabelService(failedMessageDao);
+
+    @Test
+    public void addLabelDelegatesToDao() throws Exception {
+        underTest.addLabel(FAILED_MESSAGE_ID, LABEL);
+
+        verify(failedMessageDao).addLabel(FAILED_MESSAGE_ID, LABEL);
+    }
+
+    @Test
+    public void removeLabelDelegatesToDao() throws Exception {
+        underTest.removeLabel(FAILED_MESSAGE_ID, LABEL);
+
+        verify(failedMessageDao).removeLabel(FAILED_MESSAGE_ID, LABEL);
+    }
+}

--- a/lib/spring/BUCK
+++ b/lib/spring/BUCK
@@ -19,7 +19,12 @@ prebuilt_jar(
     ]
 )
 prebuilt_jar(name="spring-boot-autoconfigure", binary_jar = ":spring-boot-autoconfigure-mvn", visibility=["PUBLIC"])
-prebuilt_jar(name="spring-boot-test", binary_jar=":spring-boot-test-mvn", visibility=["PUBLIC"])
+prebuilt_jar(
+    name="spring-boot-test",
+    binary_jar=":spring-boot-test-mvn",
+    source_jar=":spring-boot-test-src",
+    visibility=["PUBLIC"]
+)
 prebuilt_jar(
     name = "spring-context",
     binary_jar = ":spring-context-mvn",
@@ -67,6 +72,7 @@ prebuilt_jar(name='spring-tx', binary_jar=':spring-tx-mvn', visibility=["PUBLIC"
 prebuilt_jar(
     name='spring-web',
     binary_jar=':spring-web-mvn',
+    source_jar=':spring-web-src',
     visibility=["PUBLIC"]
 )
 
@@ -77,6 +83,7 @@ remote_file(name='spring-boot-autoconfigure-mvn', out='spring-boot-autoconfigure
 remote_file(name="spring-boot-mvn", out="spring-boot-1.5.3.RELEASE.jar", url="mvn:org.springframework.boot:spring-boot:jar:1.5.3.RELEASE", sha1="5fedde3489afd5dbd82f9122aaec4c9f6da3d564")
 remote_file(name="spring-boot-src", out="spring-boot-1.5.3.RELEASE-sources.jar", url="mvn:org.springframework.boot:spring-boot:src:1.5.3.RELEASE", sha1="048c2b8c7728069f168769d856b019fff6b5b998")
 remote_file(name='spring-boot-test-mvn', out='spring-boot-test-1.5.3.RELEASE.jar', url='mvn:org.springframework.boot:spring-boot-test:jar:1.5.3.RELEASE', sha1='ad57d8bacb4fc147ded7c99806f8693855f5fe29')
+remote_file(name='spring-boot-test-src', out='spring-boot-test-1.5.3.RELEASE-sources.jar', url='mvn:org.springframework.boot:spring-boot-test:src:1.5.3.RELEASE', sha1='5ffcb510e4a63573a65913928c7383f74c03950e')
 remote_file(name="spring-context-mvn", out="spring-context-4.3.8.RELEASE.jar", url="mvn:org.springframework:spring-context:jar:4.3.8.RELEASE", sha1="944073ac58ab78b78a7694d2c53d4ae9f634c815")
 remote_file(name="spring-context-src", out="spring-context-4.3.8.RELEASE-sources.jar", url="mvn:org.springframework:spring-context:src:4.3.8.RELEASE", sha1="717681088e22206f927dc8cec10a3ed1954da527")
 remote_file(name="spring-core-mvn", out="spring-core-4.3.8.RELEASE.jar", url="mvn:org.springframework:spring-core:jar:4.3.8.RELEASE", sha1="cce6c251249e48f0a86aa578c2a0e262efa5a1e0")
@@ -92,6 +99,7 @@ remote_file(name='spring-security-web-mvn', out='spring-security-web-4.2.3.RELEA
 remote_file(name='spring-test-mvn', out='spring-test-4.3.8.RELEASE.jar', url='mvn:org.springframework:spring-test:jar:4.3.8.RELEASE', sha1='37e3896fb1d3fa08235224b1a7528f806de717cc')
 remote_file(name='spring-tx-mvn', out='spring-tx-4.3.8.RELEASE.jar', url='mvn:org.springframework:spring-tx:jar:4.3.8.RELEASE', sha1='7d84a40ac7eb8548aa67b8a3ae89baa8a5eb39a0')
 remote_file(name='spring-web-mvn', out='spring-web-4.3.8.RELEASE.jar', url='mvn:org.springframework:spring-web:jar:4.3.8.RELEASE', sha1='ec1b675c2e234b0c776d36ed56c691520030026f')
+remote_file(name='spring-web-src', out='spring-web-4.3.8.RELEASE-sources.jar', url='mvn:org.springframework:spring-web:src:4.3.8.RELEASE', sha1='777555d3097d02c2de37dc6f98d093482cee295e')
 
 java_library(
     name = "spring-boot-with-dependencies",


### PR DESCRIPTION
Added the ability to Add and Remove labels via HTTP

Add Label `PUT http://localhost:9991/core/failed-message/label/{failedMessageId}/{label}`
Remove Label `DELETE http://localhost:9991/core/failed-message/label/{failedMessageId}/{label}`

Added a `LabelMessageAction` to add labels as part of message classification.