### PR TITLE
Label management via queue-triage-web

### DIFF
--- a/common/jgiven/uk/gov/dwp/queue/triage/jgiven/ThenStage.java
+++ b/common/jgiven/uk/gov/dwp/queue/triage/jgiven/ThenStage.java
@@ -1,0 +1,19 @@
+package uk.gov.dwp.queue.triage.jgiven;
+
+import com.tngtech.jgiven.annotation.IntroWord;
+import com.tngtech.jgiven.base.StageBase;
+
+public class ThenStage<SELF extends ThenStage<?>> extends StageBase<SELF> {
+
+    public ThenStage() {}
+
+    @IntroWord
+    public SELF then() {
+        return this.self();
+    }
+
+    @IntroWord
+    public SELF and() {
+        return this.self();
+    }
+}

--- a/core/client/src/main/java/uk/gov/dwp/queue/triage/core/client/label/LabelFailedMessageClient.java
+++ b/core/client/src/main/java/uk/gov/dwp/queue/triage/core/client/label/LabelFailedMessageClient.java
@@ -8,6 +8,7 @@ import javax.ws.rs.DELETE;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
+import java.util.Set;
 
 @Api(value = "Label")
 @Path("/failed-message/label")
@@ -17,6 +18,11 @@ public interface LabelFailedMessageClient {
     @PUT
     @Path("/{failedMessageId}/{label}")
     void addLabel(@PathParam("failedMessageId") FailedMessageId failedMessageId, @PathParam("label") String label);
+
+    @ApiOperation("Replace the labels on a given FailedMessage")
+    @PUT
+    @Path("/{failedMessageId}")
+    void setLabels(@PathParam("failedMessageId") FailedMessageId failedMessageId, Set<String> labels);
 
     @ApiOperation("Remove a label from a FailedMessage")
     @DELETE

--- a/core/client/src/main/java/uk/gov/dwp/queue/triage/core/client/label/LabelFailedMessageClient.java
+++ b/core/client/src/main/java/uk/gov/dwp/queue/triage/core/client/label/LabelFailedMessageClient.java
@@ -4,11 +4,14 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import uk.gov.dwp.queue.triage.id.FailedMessageId;
 
+import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import java.util.Set;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
 @Api(value = "Label")
 @Path("/failed-message/label")
@@ -22,6 +25,7 @@ public interface LabelFailedMessageClient {
     @ApiOperation("Replace the labels on a given FailedMessage")
     @PUT
     @Path("/{failedMessageId}")
+    @Consumes(APPLICATION_JSON)
     void setLabels(@PathParam("failedMessageId") FailedMessageId failedMessageId, Set<String> labels);
 
     @ApiOperation("Remove a label from a FailedMessage")

--- a/core/client/src/main/java/uk/gov/dwp/queue/triage/core/client/search/SearchFailedMessageResponse.java
+++ b/core/client/src/main/java/uk/gov/dwp/queue/triage/core/client/search/SearchFailedMessageResponse.java
@@ -5,7 +5,9 @@ import uk.gov.dwp.queue.triage.id.FailedMessageId;
 
 import javax.validation.constraints.NotNull;
 import java.time.Instant;
+import java.util.Collection;
 import java.util.Optional;
+import java.util.Set;
 
 public class SearchFailedMessageResponse {
 
@@ -19,19 +21,22 @@ public class SearchFailedMessageResponse {
     @NotNull
     private final Instant lastFailedDateTime;
     private final String content;
+    private final Set<String> labels;
 
     private SearchFailedMessageResponse(@JsonProperty("failedMessageId") FailedMessageId failedMessageId,
                                         @JsonProperty("broker") String broker,
                                         @JsonProperty("destination") Optional<String> destination,
                                         @JsonProperty("sentDateTime") Instant sentDateTime,
                                         @JsonProperty("failedDateTime") Instant lastFailedDateTime,
-                                        @JsonProperty("content") String content) {
+                                        @JsonProperty("content") String content,
+                                        @JsonProperty("labels") Set<String> labels) {
         this.failedMessageId = failedMessageId;
         this.broker = broker;
         this.destination = destination;
         this.sentDateTime = sentDateTime;
         this.lastFailedDateTime = lastFailedDateTime;
         this.content = content;
+        this.labels = labels;
     }
 
     public FailedMessageId getFailedMessageId() {
@@ -58,6 +63,10 @@ public class SearchFailedMessageResponse {
         return content;
     }
 
+    public Set<String> getLabels() {
+        return labels;
+    }
+
     public static SearchFailedMessageResponseBuilder newSearchFailedMessageResponse() {
         return new SearchFailedMessageResponseBuilder();
     }
@@ -70,6 +79,7 @@ public class SearchFailedMessageResponse {
         private Instant sentDateTime;
         private Instant failedDateTime;
         private String content;
+        private Set<String> labels;
 
         private SearchFailedMessageResponseBuilder() {
         }
@@ -104,8 +114,13 @@ public class SearchFailedMessageResponse {
             return this;
         }
 
+        public SearchFailedMessageResponseBuilder withLabels(Set<String> labels) {
+            this.labels = labels;
+            return this;
+        }
+
         public SearchFailedMessageResponse build() {
-            return new SearchFailedMessageResponse(failedMessageId, broker, destination, sentDateTime, failedDateTime, content);
+            return new SearchFailedMessageResponse(failedMessageId, broker, destination, sentDateTime, failedDateTime, content, labels);
         }
     }
 }

--- a/core/component-test/src/main/java/uk/gov/dwp/queue/triage/core/label/AddLabelWhenStage.java
+++ b/core/component-test/src/main/java/uk/gov/dwp/queue/triage/core/label/AddLabelWhenStage.java
@@ -2,6 +2,7 @@ package uk.gov.dwp.queue.triage.core.label;
 
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.tngtech.jgiven.integration.spring.JGivenStage;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.web.client.TestRestTemplate;
@@ -27,6 +28,15 @@ public class AddLabelWhenStage extends WhenStage<AddLabelWhenStage> {
         restTemplate.delete(
                 "/core/failed-message/label/{failedMessageId}/{label}",
                 ImmutableMap.of("failedMessageId", failedMessageId, "label", label)
+        );
+        return this;
+    }
+
+    public AddLabelWhenStage failedMessage$HasTheFollowingLabelsSet$(FailedMessageId failedMessageId, String... labels) {
+        restTemplate.put(
+                "/core/failed-message/label/{failedMessageId}",
+                ImmutableSet.copyOf(labels),
+                ImmutableMap.of("failedMessageId", failedMessageId)
         );
         return this;
     }

--- a/core/component-test/src/test/java/uk/gov/dwp/queue/triage/core/label/ManageLabelsComponentTest.java
+++ b/core/component-test/src/test/java/uk/gov/dwp/queue/triage/core/label/ManageLabelsComponentTest.java
@@ -11,6 +11,7 @@ import uk.gov.dwp.queue.triage.id.FailedMessageId;
 
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.emptyIterable;
 import static uk.gov.dwp.queue.triage.core.client.CreateFailedMessageRequest.newCreateFailedMessageRequest;
 import static uk.gov.dwp.queue.triage.core.domain.FailedMessageResponseMatcher.aFailedMessage;
 import static uk.gov.dwp.queue.triage.id.FailedMessageId.newFailedMessageId;
@@ -30,7 +31,24 @@ public class ManageLabelsComponentTest extends BaseCoreComponentTest<FailedMessa
         addLabelWhenStage.when().$IsAddedAsALabelToFailedMessage$("bar", failedMessageId);
 
         then().aFailedMessageWithId$Has(failedMessageId, aFailedMessage().withLabels(containsInAnyOrder("foo", "bar")));
+    }
 
+    @Test
+    public void replaceLabelsOnAFailedMessage() {
+        given().aFailedMessage(newCreateFailedMessageRequest().withFailedMessageId(failedMessageId).withBrokerName("some-broker").withLabel("something")).exists();
+
+        addLabelWhenStage.when().failedMessage$HasTheFollowingLabelsSet$(failedMessageId, "foo", "bar");
+
+        then().aFailedMessageWithId$Has(failedMessageId, aFailedMessage().withLabels(containsInAnyOrder("foo", "bar")));
+    }
+
+    @Test
+    public void replaceTheLabelsOnAFailedMessageWithAnEmptySet() {
+        given().aFailedMessage(newCreateFailedMessageRequest().withFailedMessageId(failedMessageId).withBrokerName("some-broker").withLabel("something")).exists();
+
+        addLabelWhenStage.when().failedMessage$HasTheFollowingLabelsSet$(failedMessageId);
+
+        then().aFailedMessageWithId$Has(failedMessageId, aFailedMessage().withLabels(emptyIterable()));
     }
 
     @Test

--- a/core/dao-mongo/src/main/java/uk/gov/dwp/queue/triage/core/dao/mongo/FailedMessageMongoDao.java
+++ b/core/dao-mongo/src/main/java/uk/gov/dwp/queue/triage/core/dao/mongo/FailedMessageMongoDao.java
@@ -4,7 +4,6 @@ import com.mongodb.BasicDBList;
 import com.mongodb.BasicDBObject;
 import com.mongodb.DBCollection;
 import com.mongodb.DBObject;
-import com.mongodb.QueryOperators;
 import com.mongodb.operation.OrderBy;
 import uk.gov.dwp.queue.triage.core.dao.FailedMessageDao;
 import uk.gov.dwp.queue.triage.core.domain.FailedMessage;
@@ -12,6 +11,7 @@ import uk.gov.dwp.queue.triage.core.domain.FailedMessageStatus;
 import uk.gov.dwp.queue.triage.id.FailedMessageId;
 
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.singletonList;
@@ -85,6 +85,14 @@ public class FailedMessageMongoDao implements FailedMessageDao {
         collection.update(
                 failedMessageConverter.createId(failedMessageId),
                 new BasicDBObject("$addToSet", new BasicDBObject(LABELS, label))
+        );
+    }
+
+    @Override
+    public void setLabels(FailedMessageId failedMessageId, Set<String> labels) {
+        collection.update(
+                failedMessageConverter.createId(failedMessageId),
+                new BasicDBObject("$set", new BasicDBObject(LABELS, labels))
         );
     }
 

--- a/core/dao-mongo/src/test/java/uk/gov/dwp/queue/triage/core/dao/mongo/FailedMessageMongoDaoTest.java
+++ b/core/dao-mongo/src/test/java/uk/gov/dwp/queue/triage/core/dao/mongo/FailedMessageMongoDaoTest.java
@@ -1,5 +1,6 @@
 package uk.gov.dwp.queue.triage.core.dao.mongo;
 
+import com.google.common.collect.ImmutableSet;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import uk.gov.dwp.queue.triage.core.dao.util.HashMapBuilder;
@@ -34,7 +35,6 @@ import static uk.gov.dwp.queue.triage.core.domain.FailedMessageStatus.Status.FAI
 import static uk.gov.dwp.queue.triage.core.domain.FailedMessageStatus.Status.RESEND;
 import static uk.gov.dwp.queue.triage.core.domain.FailedMessageStatus.Status.SENT;
 import static uk.gov.dwp.queue.triage.core.domain.FailedMessageStatus.failedMessageStatus;
-import static uk.gov.dwp.queue.triage.id.FailedMessageId.FAILED_MESSAGE_ID;
 import static uk.gov.dwp.queue.triage.id.FailedMessageId.newFailedMessageId;
 
 public class FailedMessageMongoDaoTest extends AbstractMongoDaoTest {
@@ -187,6 +187,15 @@ public class FailedMessageMongoDaoTest extends AbstractMongoDaoTest {
 
         //TODO: What should be the behaviour (no current use case)? Throw an Exception?  Return a Boolean?
         assertThat(collection.count(), is(0L));
+    }
+
+    @Test
+    public void setLabelsOnAFailedMessageReplacesExistingLabels() throws Exception {
+        underTest.insert(failedMessageBuilder.withLabel("something").build());
+
+        underTest.setLabels(failedMessageId, ImmutableSet.of("foo", "bar"));
+
+        assertThat(underTest.findById(failedMessageId), aFailedMessage().withLabels(containsInAnyOrder("foo", "bar")));
     }
 
     @Test

--- a/core/dao/src/main/java/uk/gov/dwp/queue/triage/core/dao/FailedMessageDao.java
+++ b/core/dao/src/main/java/uk/gov/dwp/queue/triage/core/dao/FailedMessageDao.java
@@ -5,6 +5,7 @@ import uk.gov.dwp.queue.triage.core.domain.FailedMessageStatus;
 import uk.gov.dwp.queue.triage.id.FailedMessageId;
 
 import java.util.List;
+import java.util.Set;
 
 public interface FailedMessageDao {
 
@@ -21,6 +22,8 @@ public interface FailedMessageDao {
     int removeFailedMessages();
 
     void addLabel(FailedMessageId failedMessageId, String label);
+
+    void setLabels(FailedMessageId failedMessageId, Set<String> labels);
 
     void removeLabel(FailedMessageId failedMessageId, String label);
 }

--- a/core/search/src/main/java/uk/gov/dwp/queue/triage/core/search/SearchFailedMessageResponseAdapter.java
+++ b/core/search/src/main/java/uk/gov/dwp/queue/triage/core/search/SearchFailedMessageResponseAdapter.java
@@ -15,6 +15,7 @@ public class SearchFailedMessageResponseAdapter {
                 .withFailedDateTime(failedMessage.getFailedAt())
                 .withFailedMessageId(failedMessage.getFailedMessageId())
                 .withSentDateTime(failedMessage.getSentAt())
+                .withLabels(failedMessage.getLabels())
                 .build();
     }
 }

--- a/core/server/src/main/java/uk/gov/dwp/queue/triage/core/resource/label/LabelFailedMessageResource.java
+++ b/core/server/src/main/java/uk/gov/dwp/queue/triage/core/resource/label/LabelFailedMessageResource.java
@@ -4,6 +4,8 @@ import uk.gov.dwp.queue.triage.core.client.label.LabelFailedMessageClient;
 import uk.gov.dwp.queue.triage.core.service.FailedMessageLabelService;
 import uk.gov.dwp.queue.triage.id.FailedMessageId;
 
+import java.util.Set;
+
 public class LabelFailedMessageResource implements LabelFailedMessageClient {
 
     private final FailedMessageLabelService failedMessageLabelService;
@@ -15,6 +17,11 @@ public class LabelFailedMessageResource implements LabelFailedMessageClient {
     @Override
     public void addLabel(FailedMessageId failedMessageId, String label) {
         failedMessageLabelService.addLabel(failedMessageId, label);
+    }
+
+    @Override
+    public void setLabels(FailedMessageId failedMessageId, Set<String> labels) {
+        failedMessageLabelService.setLabels(failedMessageId, labels);
     }
 
     @Override

--- a/core/service/src/main/java/uk/gov/dwp/queue/triage/core/service/FailedMessageLabelService.java
+++ b/core/service/src/main/java/uk/gov/dwp/queue/triage/core/service/FailedMessageLabelService.java
@@ -5,6 +5,8 @@ import org.slf4j.LoggerFactory;
 import uk.gov.dwp.queue.triage.core.dao.FailedMessageDao;
 import uk.gov.dwp.queue.triage.id.FailedMessageId;
 
+import java.util.Set;
+
 public class FailedMessageLabelService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(FailedMessageLabelService.class);
@@ -16,12 +18,17 @@ public class FailedMessageLabelService {
     }
 
     public void addLabel(FailedMessageId failedMessageId, String label) {
+        LOGGER.debug("Adding label '{}' to FailedMessage: {}", label, failedMessageId);
         failedMessageDao.addLabel(failedMessageId, label);
-        LOGGER.debug("Added label '{}' to FailedMessage: {}", label, failedMessageId);
     }
 
     public void removeLabel(FailedMessageId failedMessageId, String label) {
+        LOGGER.debug("Removing label '{}' from FailedMessage: {}", label, failedMessageId);
         failedMessageDao.removeLabel(failedMessageId, label);
-        LOGGER.debug("Removed label '{}' from FailedMessage: {}", label, failedMessageId);
+    }
+
+    public void setLabels(FailedMessageId failedMessageId, Set<String> labels) {
+        LOGGER.debug("Replacing all labels on FailedMessage: {}", failedMessageId);
+        failedMessageDao.setLabels(failedMessageId, labels);
     }
 }

--- a/core/service/src/test/java/uk/gov/dwp/queue/triage/core/service/FailedMessageLabelServiceTest.java
+++ b/core/service/src/test/java/uk/gov/dwp/queue/triage/core/service/FailedMessageLabelServiceTest.java
@@ -4,6 +4,9 @@ import org.junit.Test;
 import uk.gov.dwp.queue.triage.core.dao.FailedMessageDao;
 import uk.gov.dwp.queue.triage.id.FailedMessageId;
 
+import java.util.Collections;
+
+import static java.util.Collections.singleton;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -26,5 +29,12 @@ public class FailedMessageLabelServiceTest {
         underTest.removeLabel(FAILED_MESSAGE_ID, LABEL);
 
         verify(failedMessageDao).removeLabel(FAILED_MESSAGE_ID, LABEL);
+    }
+
+    @Test
+    public void setLabelsDelegatesToDao() {
+        underTest.setLabels(FAILED_MESSAGE_ID, singleton(LABEL));
+
+        verify(failedMessageDao).setLabels(FAILED_MESSAGE_ID, singleton(LABEL));
     }
 }

--- a/lib/test/BUCK
+++ b/lib/test/BUCK
@@ -80,7 +80,7 @@ java_binary(
         ':jgiven-html-app',
         ':jgiven-html5-report',
         '//lib/slf4j:slf4j-api',
-        '//lib/slf4j:slf4j-simple',
+#         '//lib/slf4j:slf4j-simple',
     ],
     visibility = [
         'PUBLIC',

--- a/web/component-test/BUCK
+++ b/web/component-test/BUCK
@@ -31,9 +31,9 @@ java_test(
         "//lib/hibernate-validator:hibernate-validator",
         '//lib/selenide:selenide',
         '//lib/selenide:selenide-dependencies',
-        '//lib/selenium/phantomjs-driver:phantomjs-driver-with-dependencies',
+#         '//lib/selenium/phantomjs-driver:phantomjs-driver-with-dependencies',
 #         '//lib/selenium/htmlunit-driver:htmlunit-driver-with-dependencies',
-#         '//lib/selenium/firefox-driver:selenium-firefox-driver-with-dependencies',
+        '//lib/selenium/firefox-driver:selenium-firefox-driver-with-dependencies',
         '//lib/spring:spring-beans',
         '//lib/spring:spring-boot-test',
         '//lib/spring:spring-context',
@@ -46,9 +46,9 @@ java_test(
     ],
     vm_args = [
 #         "-Dbrowser=htmlunit",
-#         "-Dbrowser=marionette",
-#         "-Dwebdriver.gecko.driver=/opt/geckodriver/current/geckodriver",
-        "-Dbrowser=phantomjs",
+        "-Dbrowser=marionette",
+        "-Dwebdriver.gecko.driver=lib/geckodriver/geckodriver",
+#         "-Dbrowser=phantomjs",
         "-Djgiven.report.dir=buck-out/gen/web/component-test/jgiven-reports",
     ]
 )

--- a/web/component-test/BUCK
+++ b/web/component-test/BUCK
@@ -31,9 +31,9 @@ java_test(
         "//lib/hibernate-validator:hibernate-validator",
         '//lib/selenide:selenide',
         '//lib/selenide:selenide-dependencies',
-#         '//lib/selenium/phantomjs-driver:phantomjs-driver-with-dependencies',
+#         '//lib/selenium/firefox-driver:selenium-firefox-driver-with-dependencies',
 #         '//lib/selenium/htmlunit-driver:htmlunit-driver-with-dependencies',
-        '//lib/selenium/firefox-driver:selenium-firefox-driver-with-dependencies',
+        '//lib/selenium/phantomjs-driver:phantomjs-driver-with-dependencies',
         '//lib/spring:spring-beans',
         '//lib/spring:spring-boot-test',
         '//lib/spring:spring-context',
@@ -45,10 +45,10 @@ java_test(
         '//web/server:queue-triage-web-server',
     ],
     vm_args = [
+#         "-Dbrowser=marionette",
+#         "-Dwebdriver.gecko.driver=lib/geckodriver/geckodriver",
 #         "-Dbrowser=htmlunit",
-        "-Dbrowser=marionette",
-        "-Dwebdriver.gecko.driver=lib/geckodriver/geckodriver",
-#         "-Dbrowser=phantomjs",
+        "-Dbrowser=phantomjs",
         "-Djgiven.report.dir=buck-out/gen/web/component-test/jgiven-reports",
     ]
 )

--- a/web/component-test/BUCK
+++ b/web/component-test/BUCK
@@ -27,13 +27,14 @@ java_test(
     name = "test",
     srcs = glob(['src/test/java/**/*Test.java']),
     deps = [
+        '//common/jgiven:jgiven',
         "//lib/hibernate-validator:hibernate-validator",
         '//lib/selenide:selenide',
         '//lib/selenide:selenide-dependencies',
         '//lib/selenium/phantomjs-driver:phantomjs-driver-with-dependencies',
-        '//lib/spring:spring-beans',
 #         '//lib/selenium/htmlunit-driver:htmlunit-driver-with-dependencies',
 #         '//lib/selenium/firefox-driver:selenium-firefox-driver-with-dependencies',
+        '//lib/spring:spring-beans',
         '//lib/spring:spring-boot-test',
         '//lib/spring:spring-context',
         '//lib/spring:spring-test',
@@ -46,7 +47,7 @@ java_test(
     vm_args = [
 #         "-Dbrowser=htmlunit",
 #         "-Dbrowser=marionette",
-#         "-Dwebdriver.gecko.driver=/opt/geckodriver/current/geckodriver"
+#         "-Dwebdriver.gecko.driver=/opt/geckodriver/current/geckodriver",
         "-Dbrowser=phantomjs",
         "-Djgiven.report.dir=buck-out/gen/web/component-test/jgiven-reports",
     ]

--- a/web/component-test/src/main/java/uk/gov/dwp/queue/triage/web/component/configuration/CoreClientConfiguration.java
+++ b/web/component-test/src/main/java/uk/gov/dwp/queue/triage/web/component/configuration/CoreClientConfiguration.java
@@ -4,6 +4,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import uk.gov.dwp.queue.triage.core.client.SearchFailedMessageClient;
+import uk.gov.dwp.queue.triage.core.client.label.LabelFailedMessageClient;
 
 import static org.mockito.Mockito.mock;
 
@@ -14,5 +15,10 @@ public class CoreClientConfiguration {
     @Bean
     public SearchFailedMessageClient searchFailedMessageClient() {
         return mock(SearchFailedMessageClient.class);
+    }
+
+    @Bean
+    public LabelFailedMessageClient labelFailedMessageClient() {
+        return mock(LabelFailedMessageClient.class);
     }
 }

--- a/web/component-test/src/main/java/uk/gov/dwp/queue/triage/web/component/labels/LabelManagementThenStage.java
+++ b/web/component-test/src/main/java/uk/gov/dwp/queue/triage/web/component/labels/LabelManagementThenStage.java
@@ -1,0 +1,34 @@
+package uk.gov.dwp.queue.triage.web.component.labels;
+
+import com.tngtech.jgiven.integration.spring.JGivenStage;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import uk.gov.dwp.queue.triage.core.client.label.LabelFailedMessageClient;
+import uk.gov.dwp.queue.triage.id.FailedMessageId;
+import uk.gov.dwp.queue.triage.jgiven.ThenStage;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+
+@JGivenStage
+public class LabelManagementThenStage extends ThenStage<LabelManagementThenStage> {
+
+    @Autowired
+    private LabelFailedMessageClient labelFailedMessageClient;
+
+    public LabelManagementThenStage failedMessage$IsUpdatedWithLabels$(FailedMessageId failedMessageId, String...labels) {
+        Mockito.verify(labelFailedMessageClient).setLabels(failedMessageId, new HashSet<>(Arrays.asList(labels)));
+        return this;
+    }
+
+    public LabelManagementThenStage failedMessage$IsUpdatedWithNoLabels(FailedMessageId failedMessageId) {
+        Mockito.verify(labelFailedMessageClient).setLabels(failedMessageId, Collections.emptySet());
+        return this;
+    }
+
+    public LabelManagementThenStage failedMessage$IsNotUpdated(FailedMessageId failedMessageId) {
+        Mockito.verify(labelFailedMessageClient, Mockito.never()).setLabels(Mockito.eq(failedMessageId), Mockito.anySet());
+        return this;
+    }
+}

--- a/web/component-test/src/main/java/uk/gov/dwp/queue/triage/web/component/labels/LabelManagementWhenStage.java
+++ b/web/component-test/src/main/java/uk/gov/dwp/queue/triage/web/component/labels/LabelManagementWhenStage.java
@@ -1,0 +1,27 @@
+package uk.gov.dwp.queue.triage.web.component.labels;
+
+import com.codeborne.selenide.Selenide;
+import com.tngtech.jgiven.annotation.Description;
+import org.openqa.selenium.By;
+import uk.gov.dwp.queue.triage.id.FailedMessageId;
+import uk.gov.dwp.queue.triage.jgiven.WhenStage;
+
+public class LabelManagementWhenStage extends WhenStage<LabelManagementWhenStage> {
+
+
+    @Description("the user adds label(s) '$' to failed message $")
+    public LabelManagementWhenStage labelsAddedToFailedMessage(String label, FailedMessageId failedMessageId) {
+        // Select the row
+        Selenide.$(By.cssSelector("tr[recid='" + failedMessageId + "']")).click();
+        // Double click on the row
+        Selenide.$("#grid_failed-message-list-grid_rec_" + failedMessageId).doubleClick();
+        // Set the labels
+        Selenide.$("input[recid='" + failedMessageId + "']").setValue(label);
+        return this;
+    }
+
+    public LabelManagementWhenStage theUserClicksSave() {
+        Selenide.$(By.id("tb_failed-message-list-grid_toolbar_item_w2ui-save")).click();
+        return this;
+    }
+}

--- a/web/component-test/src/main/java/uk/gov/dwp/queue/triage/web/component/labels/LabelManagementWhenStage.java
+++ b/web/component-test/src/main/java/uk/gov/dwp/queue/triage/web/component/labels/LabelManagementWhenStage.java
@@ -1,27 +1,45 @@
 package uk.gov.dwp.queue.triage.web.component.labels;
 
 import com.codeborne.selenide.Selenide;
-import com.tngtech.jgiven.annotation.Description;
+import com.codeborne.selenide.SelenideElement;
 import org.openqa.selenium.By;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import uk.gov.dwp.queue.triage.id.FailedMessageId;
 import uk.gov.dwp.queue.triage.jgiven.WhenStage;
 
 public class LabelManagementWhenStage extends WhenStage<LabelManagementWhenStage> {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(LabelManagementWhenStage.class);
 
-    @Description("the user adds label(s) '$' to failed message $")
-    public LabelManagementWhenStage labelsAddedToFailedMessage(String label, FailedMessageId failedMessageId) {
-        // Select the row
-        Selenide.$(By.cssSelector("tr[recid='" + failedMessageId + "']")).click();
-        // Double click on the row
-        Selenide.$("#grid_failed-message-list-grid_rec_" + failedMessageId).doubleClick();
-        // Set the labels
-        Selenide.$("input[recid='" + failedMessageId + "']").setValue(label);
+    public LabelManagementWhenStage theUserAddslabels$ToFailedMessage$(String labels, FailedMessageId failedMessageId) {
+        LOGGER.debug("Adding label(s): {} to failedMessage: {}", labels, failedMessageId);
+        selectCheckboxForFailedMessage(failedMessageId, true);
+
+        SelenideElement cell = Selenide.$("#grid_failedMessages_rec_" + failedMessageId + " td[col='5'] div");
+
+        // Double clicking in w2ui is actually two single-clicks < 350ms apart
+        cell.click();
+        Selenide.sleep(5);
+        cell.click();
+
+        Selenide.$("#grid_failedMessages_edit_" + failedMessageId + "_5").setValue(labels);
+
+        selectCheckboxForFailedMessage(failedMessageId, false);
         return this;
     }
 
+    private void selectCheckboxForFailedMessage(FailedMessageId failedMessageId, boolean selected) {
+        Selenide.$(By.id("grid_failedMessages_frec_" + failedMessageId))
+                .find("input[type='checkbox']")
+                .setSelected(selected);
+    }
+
     public LabelManagementWhenStage theUserClicksSave() {
-        Selenide.$(By.id("tb_failed-message-list-grid_toolbar_item_w2ui-save")).click();
+        LOGGER.debug("Saving changes to the failedMessages grid");
+        Selenide.$(By.id("tb_failedMessages_toolbar_item_w2ui-save"))
+                .find(".w2ui-button")
+                .click();
         return this;
     }
 }

--- a/web/component-test/src/main/java/uk/gov/dwp/queue/triage/web/component/list/ListFailedMessagesStage.java
+++ b/web/component-test/src/main/java/uk/gov/dwp/queue/triage/web/component/list/ListFailedMessagesStage.java
@@ -87,8 +87,9 @@ public class ListFailedMessagesStage extends Stage<ListFailedMessagesStage> {
     }
 
     public ListFailedMessagesStage theUserClicksTheReloadButton() {
+        LOGGER.debug("Reloading the failedMessages grid");
         // TODO: Investigate why this doesn't work with htmlunit-driver
-        Selenide.$(By.id("tb_failed-message-list-grid_toolbar_item_w2ui-reload"))
+        Selenide.$(By.id("tb_failedMessages_toolbar_item_w2ui-reload"))
                 .find(By.className("w2ui-button"))
                 .click();
         Selenide.$(By.className("w2ui-lock-msg")).waitUntil(not(visible), 5000);

--- a/web/component-test/src/main/java/uk/gov/dwp/queue/triage/web/component/list/ListFailedMessagesStage.java
+++ b/web/component-test/src/main/java/uk/gov/dwp/queue/triage/web/component/list/ListFailedMessagesStage.java
@@ -64,6 +64,10 @@ public class ListFailedMessagesStage extends Stage<ListFailedMessagesStage> {
         return this;
     }
 
+    public ListFailedMessagesStage theUserHasNavigatedToTheFailedMessagesPage() {
+        return theUserNavigatesToTheFailedMessagesPage();
+    }
+
     public ListFailedMessagesStage theUserNavigatesToTheFailedMessagesPage() {
         LOGGER.debug("Opening the ListFailedMessagePage");
         ListFailedMessagesPage.openListFailedMessagePage(environment);

--- a/web/component-test/src/test/java/uk/gov/dwp/queue/triage/web/component/labels/LabelManagementComponentTest.java
+++ b/web/component-test/src/test/java/uk/gov/dwp/queue/triage/web/component/labels/LabelManagementComponentTest.java
@@ -1,0 +1,88 @@
+package uk.gov.dwp.queue.triage.web.component.labels;
+
+import com.tngtech.jgiven.annotation.ScenarioStage;
+import org.junit.Test;
+import uk.gov.dwp.queue.triage.id.FailedMessageId;
+import uk.gov.dwp.queue.triage.web.component.BaseWebComponentTest;
+import uk.gov.dwp.queue.triage.web.component.list.ListFailedMessagesStage;
+import uk.gov.dwp.queue.triage.web.component.login.LoginGivenStage;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import static java.time.temporal.ChronoUnit.HOURS;
+import static java.time.temporal.ChronoUnit.MINUTES;
+import static uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageResponse.newSearchFailedMessageResponse;
+
+public class LabelManagementComponentTest extends BaseWebComponentTest<LabelManagementWhenStage> {
+
+    private static final FailedMessageId FAILED_MESSAGE_ID_1 = FailedMessageId.newFailedMessageId();
+    private static final FailedMessageId FAILED_MESSAGE_ID_2 = FailedMessageId.newFailedMessageId();
+    private static final Instant NOW = Instant.now();
+
+    @ScenarioStage
+    private LoginGivenStage loginGivenStage;
+    @ScenarioStage
+    private ListFailedMessagesStage listFailedMessagesStage;
+    @ScenarioStage
+    private LabelManagementThenStage labelManagementThenStage;
+
+    @Test
+    public void addSingleLabelToAFailedMessage() throws Exception {
+        listFailedMessagesStage.given().aFailedMessage$Exists(newSearchFailedMessageResponse()
+                .withFailedMessageId(FAILED_MESSAGE_ID_1)
+                .withBroker("main-broker")
+                .withDestination(Optional.of("queue-name"))
+                .withSentDateTime(NOW.minus(1, MINUTES))
+                .withFailedDateTime(NOW)
+                .withContent("Boom")
+        );
+        listFailedMessagesStage.given().and().aFailedMessage$Exists(newSearchFailedMessageResponse()
+                .withFailedMessageId(FAILED_MESSAGE_ID_2)
+                .withBroker("another-broker")
+                .withDestination(Optional.of("topic-name"))
+                .withSentDateTime(NOW.minus(1, HOURS))
+                .withFailedDateTime(NOW.minus(2, MINUTES))
+                .withContent("Failure")
+        );
+        listFailedMessagesStage.given().and().theSearchResultsWillContainFailedMessages$(FAILED_MESSAGE_ID_1, FAILED_MESSAGE_ID_2);
+        loginGivenStage.given().and().theUserHasSuccessfullyLoggedOn();
+        listFailedMessagesStage.given().and().theUserHasNavigatedToTheFailedMessagesPage();
+
+        when().labelsAddedToFailedMessage("foo", FAILED_MESSAGE_ID_1);
+        when().and().labelsAddedToFailedMessage("label1, label2", FAILED_MESSAGE_ID_2);
+        when().and().theUserClicksSave();
+
+        labelManagementThenStage.then().failedMessage$IsUpdatedWithLabels$(FAILED_MESSAGE_ID_1, "foo");
+        labelManagementThenStage.then().and().failedMessage$IsUpdatedWithLabels$(FAILED_MESSAGE_ID_2, "label1", "label2");
+    }
+
+    @Test
+    public void removeLabelsFromAFailedMessage() throws Exception {
+        listFailedMessagesStage.given().aFailedMessage$Exists(newSearchFailedMessageResponse()
+                .withFailedMessageId(FAILED_MESSAGE_ID_1)
+                .withBroker("main-broker")
+                .withDestination(Optional.of("queue-name"))
+                .withSentDateTime(NOW.minus(1, MINUTES))
+                .withFailedDateTime(NOW)
+                .withContent("Boom")
+        );
+        listFailedMessagesStage.given().and().aFailedMessage$Exists(newSearchFailedMessageResponse()
+                .withFailedMessageId(FAILED_MESSAGE_ID_2)
+                .withBroker("another-broker")
+                .withDestination(Optional.of("topic-name"))
+                .withSentDateTime(NOW.minus(1, HOURS))
+                .withFailedDateTime(NOW.minus(2, MINUTES))
+                .withContent("Failure")
+        );
+        listFailedMessagesStage.given().and().theSearchResultsWillContainFailedMessages$(FAILED_MESSAGE_ID_1, FAILED_MESSAGE_ID_2);
+        loginGivenStage.given().and().theUserHasSuccessfullyLoggedOn();
+        listFailedMessagesStage.given().and().theUserHasNavigatedToTheFailedMessagesPage();
+
+        when().labelsAddedToFailedMessage("", FAILED_MESSAGE_ID_1);
+        when().and().theUserClicksSave();
+
+        labelManagementThenStage.then().failedMessage$IsUpdatedWithNoLabels(FAILED_MESSAGE_ID_1);
+        labelManagementThenStage.then().and().failedMessage$IsNotUpdated(FAILED_MESSAGE_ID_2);
+    }
+}

--- a/web/component-test/src/test/java/uk/gov/dwp/queue/triage/web/component/labels/LabelManagementComponentTest.java
+++ b/web/component-test/src/test/java/uk/gov/dwp/queue/triage/web/component/labels/LabelManagementComponentTest.java
@@ -49,8 +49,8 @@ public class LabelManagementComponentTest extends BaseWebComponentTest<LabelMana
         loginGivenStage.given().and().theUserHasSuccessfullyLoggedOn();
         listFailedMessagesStage.given().and().theUserHasNavigatedToTheFailedMessagesPage();
 
-        when().labelsAddedToFailedMessage("foo", FAILED_MESSAGE_ID_1);
-        when().and().labelsAddedToFailedMessage("label1, label2", FAILED_MESSAGE_ID_2);
+        when().theUserAddslabels$ToFailedMessage$("foo", FAILED_MESSAGE_ID_1);
+        when().and().theUserAddslabels$ToFailedMessage$("label1, label2", FAILED_MESSAGE_ID_2);
         when().and().theUserClicksSave();
 
         labelManagementThenStage.then().failedMessage$IsUpdatedWithLabels$(FAILED_MESSAGE_ID_1, "foo");
@@ -79,7 +79,7 @@ public class LabelManagementComponentTest extends BaseWebComponentTest<LabelMana
         loginGivenStage.given().and().theUserHasSuccessfullyLoggedOn();
         listFailedMessagesStage.given().and().theUserHasNavigatedToTheFailedMessagesPage();
 
-        when().labelsAddedToFailedMessage("", FAILED_MESSAGE_ID_1);
+        when().theUserAddslabels$ToFailedMessage$("", FAILED_MESSAGE_ID_1);
         when().and().theUserClicksSave();
 
         labelManagementThenStage.then().failedMessage$IsUpdatedWithNoLabels(FAILED_MESSAGE_ID_1);

--- a/web/server/src/main/java/uk/gov/dwp/queue/triage/web/server/api/FailedMessageChangeResource.java
+++ b/web/server/src/main/java/uk/gov/dwp/queue/triage/web/server/api/FailedMessageChangeResource.java
@@ -1,0 +1,37 @@
+package uk.gov.dwp.queue.triage.web.server.api;
+
+import uk.gov.dwp.queue.triage.core.client.label.LabelFailedMessageClient;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static uk.gov.dwp.queue.triage.id.FailedMessageId.fromString;
+
+@Path("api/failed-messages")
+@Consumes(APPLICATION_JSON)
+@Produces(APPLICATION_JSON)
+public class FailedMessageChangeResource {
+
+    private final LabelFailedMessageClient labelFailedMessageClient;
+    private final LabelExtractor labelExtractor;
+
+    public FailedMessageChangeResource(LabelFailedMessageClient labelFailedMessageClient,
+                                       LabelExtractor labelExtractor) {
+        this.labelFailedMessageClient = labelFailedMessageClient;
+        this.labelExtractor = labelExtractor;
+    }
+
+    @POST
+    @Path("/labels")
+    public String updateLabelsOnFailedMessages(LabelRequest request) {
+        request.getChanges()
+                .forEach(change -> labelFailedMessageClient.setLabels(
+                        fromString(change.getRecid()),
+                        labelExtractor.extractLabels(change.getLabels())));
+        return "{ 'status': 'success' }";
+    }
+
+}

--- a/web/server/src/main/java/uk/gov/dwp/queue/triage/web/server/api/LabelExtractor.java
+++ b/web/server/src/main/java/uk/gov/dwp/queue/triage/web/server/api/LabelExtractor.java
@@ -1,0 +1,17 @@
+package uk.gov.dwp.queue.triage.web.server.api;
+
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toSet;
+import static org.apache.cxf.common.util.StringUtils.split;
+
+public class LabelExtractor {
+
+    public Set<String> extractLabels(String labels) {
+        return Stream.of(split(labels, ","))
+                .map(String::trim)
+                .filter(label -> !label.isEmpty())
+                .collect(toSet());
+    }
+}

--- a/web/server/src/main/java/uk/gov/dwp/queue/triage/web/server/api/LabelRequest.java
+++ b/web/server/src/main/java/uk/gov/dwp/queue/triage/web/server/api/LabelRequest.java
@@ -1,0 +1,68 @@
+package uk.gov.dwp.queue.triage.web.server.api;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.dwp.queue.triage.id.FailedMessageId;
+import uk.gov.dwp.queue.triage.web.server.w2ui.BaseW2UIRequest;
+
+import java.util.List;
+
+public class LabelRequest extends BaseW2UIRequest {
+
+    private final List<Change> changes;
+
+    public LabelRequest(@JsonProperty("cmd") String cmd,
+                        @JsonProperty("limit") Integer limit,
+                        @JsonProperty("offset") Integer offset,
+                        @JsonProperty("selected") List<String> selected,
+                        @JsonProperty("changes") List<Change> changes) {
+        super(cmd, limit, offset, selected);
+        this.changes = changes;
+    }
+
+    public List<Change> getChanges() {
+        return changes;
+    }
+
+    public static class Change {
+
+        private final String recid;
+        private final String labels;
+
+        public Change(@JsonProperty("recid") String recid,
+                      @JsonProperty("labels") String labels) {
+            this.recid = recid;
+            this.labels = labels;
+        }
+
+        public String getRecid() {
+            return recid;
+        }
+
+        public String getLabels() {
+            return labels;
+        }
+
+        public static ChangeBuilder newChange() {
+            return new ChangeBuilder();
+        }
+
+        public static class ChangeBuilder {
+            private String recid;
+            private String labels;
+
+            public ChangeBuilder withRecid(FailedMessageId failedMessageId) {
+                this.recid = failedMessageId.toString();
+                return this;
+            }
+
+            public ChangeBuilder withLabels(String labels) {
+                this.labels = labels;
+                return this;
+            }
+
+            public Change build() {
+                return new Change(recid, labels);
+            }
+        }
+    }
+}

--- a/web/server/src/main/java/uk/gov/dwp/queue/triage/web/server/configuration/ControllerConfiguration.java
+++ b/web/server/src/main/java/uk/gov/dwp/queue/triage/web/server/configuration/ControllerConfiguration.java
@@ -6,10 +6,13 @@ import org.springframework.context.annotation.Import;
 import uk.gov.dwp.migration.mongo.demo.cxf.client.CxfConfiguration;
 import uk.gov.dwp.migration.mongo.demo.cxf.client.ResourceRegistry;
 import uk.gov.dwp.queue.triage.core.client.SearchFailedMessageClient;
+import uk.gov.dwp.queue.triage.core.client.label.LabelFailedMessageClient;
 import uk.gov.dwp.queue.triage.jackson.configuration.JacksonConfiguration;
+import uk.gov.dwp.queue.triage.web.server.api.FailedMessageChangeResource;
 import uk.gov.dwp.queue.triage.web.server.home.HomeController;
 import uk.gov.dwp.queue.triage.web.server.list.FailedMessageListController;
 import uk.gov.dwp.queue.triage.web.server.list.FailedMessageListItemAdapter;
+import uk.gov.dwp.queue.triage.web.server.api.LabelExtractor;
 import uk.gov.dwp.queue.triage.web.server.login.AuthenticationExceptionAdapter;
 import uk.gov.dwp.queue.triage.web.server.login.LoginController;
 
@@ -37,6 +40,15 @@ public class ControllerConfiguration {
         return resourceRegistry.add(new FailedMessageListController(
                 searchFailedMessageClient,
                 new FailedMessageListItemAdapter()
+        ));
+    }
+
+    @Bean
+    public FailedMessageChangeResource failedMessageChangeResource(ResourceRegistry resourceRegistry,
+                                                                   LabelFailedMessageClient labelFailedMessageClient) {
+        return resourceRegistry.add(new FailedMessageChangeResource(
+                labelFailedMessageClient,
+                new LabelExtractor()
         ));
     }
 }

--- a/web/server/src/main/java/uk/gov/dwp/queue/triage/web/server/configuration/CoreClientConfiguration.java
+++ b/web/server/src/main/java/uk/gov/dwp/queue/triage/web/server/configuration/CoreClientConfiguration.java
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Profile;
 import uk.gov.dwp.queue.triage.core.client.SearchFailedMessageClient;
+import uk.gov.dwp.queue.triage.core.client.label.LabelFailedMessageClient;
 import uk.gov.dwp.queue.triage.jackson.configuration.JacksonConfiguration;
 
 import static java.util.Collections.singletonList;
@@ -22,6 +23,16 @@ public class CoreClientConfiguration {
         return JAXRSClientFactory.create(
                 clientProperties.getCore().getUrl(),
                 SearchFailedMessageClient.class,
+                singletonList(jacksonJsonProvider)
+        );
+    }
+
+    @Bean
+    public LabelFailedMessageClient labelFailedMessageClient(JacksonJsonProvider jacksonJsonProvider,
+                                                             ClientProperties clientProperties) {
+        return JAXRSClientFactory.create(
+                clientProperties.getCore().getUrl(),
+                LabelFailedMessageClient.class,
                 singletonList(jacksonJsonProvider)
         );
     }

--- a/web/server/src/main/java/uk/gov/dwp/queue/triage/web/server/list/FailedMessageListController.java
+++ b/web/server/src/main/java/uk/gov/dwp/queue/triage/web/server/list/FailedMessageListController.java
@@ -1,5 +1,6 @@
 package uk.gov.dwp.queue.triage.web.server.list;
 
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.dwp.queue.triage.core.client.SearchFailedMessageClient;
 import uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageResponse;
@@ -11,15 +12,16 @@ import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
 import java.util.Collection;
 
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.MediaType.TEXT_HTML;
 import static uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageRequest.newSearchFailedMessageRequest;
 
 @Path("/failed-messages")
 public class FailedMessageListController {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(FailedMessageListController.class);
     private final SearchFailedMessageClient searchFailedMessageClient;
     private final FailedMessageListItemAdapter failedMessageListItemAdapter;
 
@@ -30,7 +32,7 @@ public class FailedMessageListController {
     }
 
     @GET
-    @Consumes(MediaType.APPLICATION_JSON)
+    @Consumes(APPLICATION_JSON)
     @Produces(TEXT_HTML)
     public FailedMessageListPage getFailedMessages() {
         return new FailedMessageListPage();
@@ -38,10 +40,10 @@ public class FailedMessageListController {
 
     @POST
     @Path("/data")
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(APPLICATION_JSON)
+    @Produces(APPLICATION_JSON)
     public W2UIResponse<FailedMessageListItem> getData(BaseW2UIRequest request) {
-        LoggerFactory.getLogger(FailedMessageListController.class).info("Getting data");
+        LOGGER.info("Getting data");
         Collection<SearchFailedMessageResponse> failedMessages = searchFailedMessageClient
                 .search(newSearchFailedMessageRequest().build());
         return new W2UIResponse<>(

--- a/web/server/src/main/java/uk/gov/dwp/queue/triage/web/server/list/FailedMessageListItem.java
+++ b/web/server/src/main/java/uk/gov/dwp/queue/triage/web/server/list/FailedMessageListItem.java
@@ -16,18 +16,22 @@ public class FailedMessageListItem {
     private final String sentDateTime;
     @JsonProperty
     private final String failedDateTime;
+    @JsonProperty
+    private final String labels;
 
     public FailedMessageListItem(String recid,
                                  String content,
                                  String broker,
                                  String destination,
                                  String sentDateTime,
-                                 String failedDateTime) {
+                                 String failedDateTime,
+                                 String labels) {
         this.recid = recid;
         this.content = content;
         this.broker = broker;
         this.destination = destination;
         this.sentDateTime = sentDateTime;
         this.failedDateTime = failedDateTime;
+        this.labels = labels;
     }
 }

--- a/web/server/src/main/java/uk/gov/dwp/queue/triage/web/server/list/FailedMessageListItemAdapter.java
+++ b/web/server/src/main/java/uk/gov/dwp/queue/triage/web/server/list/FailedMessageListItemAdapter.java
@@ -7,6 +7,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 import static java.time.ZoneOffset.UTC;
@@ -25,7 +26,10 @@ public class FailedMessageListItemAdapter {
                         fm.getBroker(),
                         fm.getDestination().orElse(null),
                         toString(fm.getSentDateTime()),
-                        toString(fm.getLastFailedDateTime())))
+                        toString(fm.getLastFailedDateTime()),
+                        Optional.ofNullable(fm.getLabels())
+                                .map(labels -> labels.stream().collect(Collectors.joining(", ")))
+                                .orElse(null)))
                 .collect(Collectors.toList());
     }
 

--- a/web/server/src/main/java/uk/gov/dwp/queue/triage/web/server/w2ui/BaseW2UIRequest.java
+++ b/web/server/src/main/java/uk/gov/dwp/queue/triage/web/server/w2ui/BaseW2UIRequest.java
@@ -1,9 +1,11 @@
 package uk.gov.dwp.queue.triage.web.server.w2ui;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class BaseW2UIRequest {
 
     @JsonProperty

--- a/web/server/src/main/resources/mustache/list.mustache
+++ b/web/server/src/main/resources/mustache/list.mustache
@@ -17,14 +17,15 @@
         $('#failed-message-list-grid').w2grid({
             name: 'failed-message-list-grid',
             url: {
-                get: '/web/failed-messages/data'
+                get: '/web/failed-messages/data',
+                save: '/web/api/failed-messages/labels'
             },
             show: {
                 selectColumn: true,
                 toolbar: true,
-                toolbarSearch: false
+                toolbarSearch: false,
 //                toolbarDelete: true,
-//                toolbarSave: true
+                toolbarSave: true
             },
             columns: [
                 { field: 'recid', caption: 'Failed Message Id', size: '220px', sortable: true },
@@ -32,6 +33,7 @@
                 { field: 'destination', caption: 'Queue', size: '10%', sortable: true },
                 { field: 'sentDateTime', caption: 'Originally Sent', size: '160px', sortable: true },
                 { field: 'failedDateTime', caption: 'Failed', size: '160px', sortable: true },
+                { field: 'labels', caption: 'Labels', size: '20%', editable: { type: 'text' } },
                 { field: 'content', caption: 'Content', size: '80%', sortable: true },
             ]
         });

--- a/web/server/src/main/resources/mustache/list.mustache
+++ b/web/server/src/main/resources/mustache/list.mustache
@@ -15,7 +15,7 @@
     w2utils.settings['dataType'] = 'JSON';
     $(function () {
         $('#failed-message-list-grid').w2grid({
-            name: 'failed-message-list-grid',
+            name: 'failedMessages',
             url: {
                 get: '/web/failed-messages/data',
                 save: '/web/api/failed-messages/labels'

--- a/web/server/src/test/java/uk/gov/dwp/queue/triage/web/server/api/FailedMessageChangeResourceTest.java
+++ b/web/server/src/test/java/uk/gov/dwp/queue/triage/web/server/api/FailedMessageChangeResourceTest.java
@@ -1,0 +1,62 @@
+package uk.gov.dwp.queue.triage.web.server.api;
+
+import org.junit.Test;
+import uk.gov.dwp.queue.triage.core.client.label.LabelFailedMessageClient;
+import uk.gov.dwp.queue.triage.id.FailedMessageId;
+import uk.gov.dwp.queue.triage.web.server.api.LabelRequest.Change.ChangeBuilder;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.util.Collections.emptyList;
+import static java.util.stream.Collectors.toList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.dwp.queue.triage.web.server.api.LabelRequest.Change.newChange;
+
+public class FailedMessageChangeResourceTest {
+
+    private static final FailedMessageId FAILED_MESSAGE_1_ID = FailedMessageId.newFailedMessageId();
+    private static final FailedMessageId FAILED_MESSAGE_2_ID = FailedMessageId.newFailedMessageId();
+
+    private final LabelFailedMessageClient labelFailedMessageClient = mock(LabelFailedMessageClient.class);
+    private final LabelExtractor labelExtractor = mock(LabelExtractor.class);
+    private final FailedMessageChangeResource underTest = new FailedMessageChangeResource(
+            labelFailedMessageClient,
+            labelExtractor
+    );
+    private final Set labels1 = mock(Set.class);
+    private final Set labels2 = mock(Set.class);
+
+    @Test
+    public void updateLabels() throws Exception {
+        when(labelExtractor.extractLabels("foo, bar")).thenReturn(labels1);
+        when(labelExtractor.extractLabels("black, white")).thenReturn(labels2);
+
+        String result = underTest.updateLabelsOnFailedMessages(labelRequest(
+                newChange().withRecid(FAILED_MESSAGE_1_ID).withLabels("foo, bar"),
+                newChange().withRecid(FAILED_MESSAGE_2_ID).withLabels("black, white")
+        ));
+
+        assertThat(result, is(equalTo("{ 'status': 'success' }")));
+        verify(labelFailedMessageClient).setLabels(FAILED_MESSAGE_1_ID, labels1);
+        verify(labelFailedMessageClient).setLabels(FAILED_MESSAGE_2_ID, labels2);
+
+    }
+
+    private LabelRequest labelRequest(ChangeBuilder...changeBuilders) {
+        return new LabelRequest(
+                "cmd",
+                0,
+                0,
+                emptyList(),
+                Stream.of(changeBuilders).map(ChangeBuilder::build).collect(toList()));
+    }
+}

--- a/web/server/src/test/java/uk/gov/dwp/queue/triage/web/server/api/LabelExtractorTest.java
+++ b/web/server/src/test/java/uk/gov/dwp/queue/triage/web/server/api/LabelExtractorTest.java
@@ -1,0 +1,34 @@
+package uk.gov.dwp.queue.triage.web.server.api;
+
+import org.junit.Test;
+import uk.gov.dwp.queue.triage.web.server.api.LabelExtractor;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.emptyIterable;
+import static org.hamcrest.Matchers.is;
+
+public class LabelExtractorTest {
+
+    private final LabelExtractor underTest = new LabelExtractor();
+
+    @Test
+    public void emptyStingReturnsEmptySet() throws Exception {
+        assertThat(underTest.extractLabels(""), is(emptyIterable()));
+    }
+
+    @Test
+    public void stringContainingWhitespaceReturnsEmptySet() throws Exception {
+        assertThat(underTest.extractLabels(" \t"), is(emptyIterable()));
+    }
+
+    @Test
+    public void stringContainingOnlyCommasWhitespaceReturnsEmptySet() throws Exception {
+        assertThat(underTest.extractLabels(" ,,\t,"), is(emptyIterable()));
+    }
+
+    @Test
+    public void leadingAndTrailingWhitespaceIsRemovedFromLabels() {
+        assertThat(underTest.extractLabels(" foo , bar\t"), containsInAnyOrder("foo", "bar"));
+    }
+}

--- a/web/server/src/test/java/uk/gov/dwp/queue/triage/web/server/list/FailedMessageListItemAdapterTest.java
+++ b/web/server/src/test/java/uk/gov/dwp/queue/triage/web/server/list/FailedMessageListItemAdapterTest.java
@@ -12,6 +12,7 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -19,7 +20,9 @@ import static java.time.ZoneOffset.UTC;
 import static java.time.temporal.ChronoField.MILLI_OF_SECOND;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
 import static org.valid4j.matchers.jsonpath.JsonPathMatchers.hasJsonPath;
 
 public class FailedMessageListItemAdapterTest {
@@ -48,6 +51,7 @@ public class FailedMessageListItemAdapterTest {
                 .withSentDateTime(SOME_DATE_TIME)
                 .withFailedDateTime(SOME_DATE_TIME.with(MILLI_OF_SECOND, 123))
                 .withContent("More Content")
+                .withLabels(new HashSet<>(Arrays.asList("aaa","bbb")))
                 .build();
 
         String json = OBJECT_MAPPER.writeValueAsString(underTest.adapt(Arrays.asList(failedMessage1, failedMessage2)));
@@ -59,13 +63,15 @@ public class FailedMessageListItemAdapterTest {
                 hasJsonPath("$.[0].destination", equalTo("queue-name")),
                 hasJsonPath("$.[0].sentDateTime", equalTo("1970-01-01T00:00:00.000Z")),
                 hasJsonPath("$.[0].failedDateTime", equalTo("2016-02-08T14:43:00.000Z")),
+                hasJsonPath("$.[0].labels", nullValue()),
 
                 hasJsonPath("$.[1].recid", equalTo(FAILED_MESSAGE_ID_2)),
                 hasJsonPath("$.[1].broker", equalTo("internal-broker")),
                 hasJsonPath("$.[1].content", equalTo("More Content")),
                 hasJsonPath("$.[1].destination", equalTo("another-queue")),
                 hasJsonPath("$.[1].sentDateTime", equalTo("2016-02-08T14:43:00.000Z")),
-                hasJsonPath("$.[1].failedDateTime", equalTo("2016-02-08T14:43:00.123Z"))
+                hasJsonPath("$.[1].failedDateTime", equalTo("2016-02-08T14:43:00.123Z")),
+                hasJsonPath("$.[1].labels", equalTo("aaa, bbb"))
         ));
     }
 }


### PR DESCRIPTION
Adds the ability to add, edit and remove labels for Failed Messages from `queue-triage-web`.

Added `geckodriver` (v0.18.0) and `phantomjs` (v2.1.1) to the repo.