### PR TITLE
Issue 86 - Add search to Queue Triage Web

### DIFF
--- a/common/ldap-test-support/BUCK
+++ b/common/ldap-test-support/BUCK
@@ -1,5 +1,5 @@
 java_library(
-    name = "queue-traige-ldap-test-support",
+    name = "queue-triage-ldap-test-support",
     srcs = glob(["src/main/java/**/*.java"]),
     resources = [
         "src/main/resources/example.ldif"

--- a/core/client-test-support/BUCK
+++ b/core/client-test-support/BUCK
@@ -12,6 +12,7 @@ java_library(
         '//core/component-test/...',
         '//core/resend:test',
         '//core/server:test',
+        '//web/component-test/...',
         '//web/server:test',
     ],
 )

--- a/core/client-test-support/src/main/java/uk/gov/dwp/queue/triage/core/client/SearchFailedMessageRequestMatcher.java
+++ b/core/client-test-support/src/main/java/uk/gov/dwp/queue/triage/core/client/SearchFailedMessageRequestMatcher.java
@@ -6,18 +6,29 @@ import org.hamcrest.TypeSafeMatcher;
 import org.hamcrest.core.IsAnything;
 import uk.gov.dwp.queue.triage.core.client.FailedMessageStatus;
 import uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageRequest;
+import uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageRequest.Operator;
 
 import java.util.Optional;
 
+import static org.hamcrest.Matchers.equalTo;
+
 public class SearchFailedMessageRequestMatcher extends TypeSafeMatcher<SearchFailedMessageRequest> {
 
+    private final Matcher<Operator> operatorMatcher;
     private Matcher<Optional<String>> brokerMatcher = new IsAnything<>();
-    private Matcher<Iterable<? extends FailedMessageStatus>> statusMatcher = new IsAnything<>();
+    private Matcher<Optional<String>> contentMatcher = new IsAnything<>();
     private Matcher<Optional<String>> destinationMatcher = new IsAnything<>();
+    private Matcher<Iterable<? extends FailedMessageStatus>> statusMatcher = new IsAnything<>();
+
+    private SearchFailedMessageRequestMatcher(Matcher<Operator> operatorMatcher) {
+        this.operatorMatcher = operatorMatcher;
+    }
 
     @Override
     protected boolean matchesSafely(SearchFailedMessageRequest searchFailedMessageRequest) {
-        return brokerMatcher.matches(searchFailedMessageRequest.getBroker())
+        return operatorMatcher.matches(searchFailedMessageRequest.getOperator())
+                && brokerMatcher.matches(searchFailedMessageRequest.getBroker())
+                && contentMatcher.matches(searchFailedMessageRequest.getContent())
                 && destinationMatcher.matches(searchFailedMessageRequest.getDestination())
                 && statusMatcher.matches(searchFailedMessageRequest.getStatuses())
                 ;
@@ -25,11 +36,20 @@ public class SearchFailedMessageRequestMatcher extends TypeSafeMatcher<SearchFai
 
     @Override
     public void describeTo(Description description) {
-
+        description
+                .appendText("operator ").appendDescriptionOf(operatorMatcher)
+                .appendText(" broker ").appendDescriptionOf(brokerMatcher)
+                .appendText(" content ").appendDescriptionOf(contentMatcher)
+                .appendText(" destination ").appendDescriptionOf(destinationMatcher)
+                .appendText(" status ").appendDescriptionOf(statusMatcher);
     }
 
-    public static SearchFailedMessageRequestMatcher aSearchRequest() {
-        return new SearchFailedMessageRequestMatcher();
+    public static SearchFailedMessageRequestMatcher aSearchRequestMatchingAllCriteria() {
+        return new SearchFailedMessageRequestMatcher(equalTo(Operator.AND));
+    }
+
+    public static SearchFailedMessageRequestMatcher aSearchRequestMatchingAnyCriteria() {
+        return new SearchFailedMessageRequestMatcher(equalTo(Operator.OR));
     }
 
     public SearchFailedMessageRequestMatcher withBroker(Matcher<Optional<String>> brokerMatcher) {
@@ -37,8 +57,28 @@ public class SearchFailedMessageRequestMatcher extends TypeSafeMatcher<SearchFai
         return this;
     }
 
+    public SearchFailedMessageRequestMatcher withBroker(String broker) {
+        this.brokerMatcher = equalTo(Optional.of(broker));
+        return this;
+    }
+
+    public SearchFailedMessageRequestMatcher withContent(Matcher<Optional<String>> contentMatcher) {
+        this.contentMatcher = contentMatcher;
+        return this;
+    }
+
+    public SearchFailedMessageRequestMatcher withContent(String content) {
+        this.contentMatcher = equalTo(Optional.of(content));
+        return this;
+    }
+
     public SearchFailedMessageRequestMatcher withDestination(Matcher<Optional<String>> destinationMatcher) {
         this.destinationMatcher = destinationMatcher;
+        return this;
+    }
+
+    public SearchFailedMessageRequestMatcher withDestination(String destination) {
+        this.destinationMatcher = equalTo(Optional.of(destination));
         return this;
     }
 

--- a/core/client/src/main/java/uk/gov/dwp/queue/triage/core/client/search/SearchFailedMessageRequest.java
+++ b/core/client/src/main/java/uk/gov/dwp/queue/triage/core/client/search/SearchFailedMessageRequest.java
@@ -7,21 +7,36 @@ import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 
+import static org.apache.commons.lang3.builder.ToStringBuilder.reflectionToString;
+import static uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageRequest.Operator.AND;
+import static uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageRequest.Operator.OR;
+
 public class SearchFailedMessageRequest {
 
     private final Optional<String> broker;
     private final Optional<String> destination;
     private final Set<FailedMessageStatus> statuses;
     private final Optional<String> content;
+    private final Operator operator;
+
+    public static SearchFailedMessageRequestBuilder searchMatchingAllCriteria() {
+        return new SearchFailedMessageRequestBuilder(AND);
+    }
+
+    public static SearchFailedMessageRequestBuilder searchMatchingAnyCriteria() {
+        return new SearchFailedMessageRequestBuilder(OR);
+    }
 
     private SearchFailedMessageRequest(@JsonProperty("broker") Optional<String> broker,
                                        @JsonProperty("destination") Optional<String> destination,
                                        @JsonProperty("statuses") Set<FailedMessageStatus> statuses,
-                                       @JsonProperty("content") Optional<String> content) {
+                                       @JsonProperty("content") Optional<String> content,
+                                       @JsonProperty("operator") Operator operator) {
         this.broker = broker;
         this.destination = destination;
         this.statuses = statuses;
         this.content = content;
+        this.operator = operator;
     }
 
     public Optional<String> getBroker() {
@@ -40,8 +55,17 @@ public class SearchFailedMessageRequest {
         return content;
     }
 
-    public static SearchFailedMessageRequestBuilder newSearchFailedMessageRequest() {
-        return new SearchFailedMessageRequestBuilder();
+    public Operator getOperator() {
+        return operator;
+    }
+
+    @Override
+    public String toString() {
+        return reflectionToString(this);
+    }
+
+    public enum Operator {
+        AND, OR
     }
 
     public static class SearchFailedMessageRequestBuilder {
@@ -50,8 +74,11 @@ public class SearchFailedMessageRequest {
         private Optional<String> destination = Optional.empty();
         private Set<FailedMessageStatus> statuses = new HashSet<>();
         private Optional<String> content = Optional.empty();
+        private Operator operator;
 
-        private SearchFailedMessageRequestBuilder() {}
+        private SearchFailedMessageRequestBuilder(Operator operator) {
+            this.operator = operator;
+        }
 
         public SearchFailedMessageRequestBuilder withBroker(String broker) {
             this.broker = Optional.ofNullable(broker);
@@ -89,7 +116,7 @@ public class SearchFailedMessageRequest {
         }
 
         public SearchFailedMessageRequest build() {
-            return new SearchFailedMessageRequest(broker, destination, statuses, content);
+            return new SearchFailedMessageRequest(broker, destination, statuses, content, operator);
         }
     }
 }

--- a/core/client/src/test/java/uk/gov/dwp/queue/triage/core/client/search/SearchFailedMessageRequestTest.java
+++ b/core/client/src/test/java/uk/gov/dwp/queue/triage/core/client/search/SearchFailedMessageRequestTest.java
@@ -11,7 +11,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static uk.gov.dwp.queue.triage.core.client.FailedMessageStatus.FAILED;
-import static uk.gov.dwp.queue.triage.core.domain.SearchFailedMessageRequestMatcher.aSearchRequest;
+import static uk.gov.dwp.queue.triage.core.domain.SearchFailedMessageRequestMatcher.aSearchRequestMatchingAllCriteria;
 
 public class SearchFailedMessageRequestTest {
 
@@ -21,12 +21,12 @@ public class SearchFailedMessageRequestTest {
     @Test
     public void serialiseAndDeserialiseWithOptionalFieldsMissing() throws Exception {
         String json = OBJECT_MAPPER.writeValueAsString(
-                SearchFailedMessageRequest.newSearchFailedMessageRequest()
+                SearchFailedMessageRequest.searchMatchingAllCriteria()
                         .withStatus(FAILED)
                         .build());
 
         assertThat(OBJECT_MAPPER.readValue(json, SearchFailedMessageRequest.class), is(
-                aSearchRequest()
+                aSearchRequestMatchingAllCriteria()
                         .withBroker(equalTo(Optional.empty()))
                         .withDestination(equalTo(Optional.empty()))
                         .withStatusMatcher(contains(FAILED))
@@ -36,14 +36,14 @@ public class SearchFailedMessageRequestTest {
     @Test
     public void serialiseAndDeserialiseWithAllFieldsPopulated() throws Exception {
         String json = OBJECT_MAPPER.writeValueAsString(
-                SearchFailedMessageRequest.newSearchFailedMessageRequest()
+                SearchFailedMessageRequest.searchMatchingAllCriteria()
                         .withBroker("broker")
                         .withDestination("queue")
                         .withStatus(FAILED)
                         .build());
 
         assertThat(OBJECT_MAPPER.readValue(json, SearchFailedMessageRequest.class), is(
-                aSearchRequest()
+                aSearchRequestMatchingAllCriteria()
                         .withBroker(equalTo(Optional.of("broker")))
                         .withDestination(equalTo(Optional.of("queue")))
                         .withStatusMatcher(contains(FAILED))

--- a/core/component-test/src/test/java/uk/gov/dwp/queue/triage/core/classification/ClassifyFailedMessageComponentTest.java
+++ b/core/component-test/src/test/java/uk/gov/dwp/queue/triage/core/classification/ClassifyFailedMessageComponentTest.java
@@ -13,7 +13,7 @@ import uk.gov.dwp.queue.triage.id.FailedMessageId;
 
 import static org.hamcrest.Matchers.equalTo;
 import static uk.gov.dwp.queue.triage.core.client.CreateFailedMessageRequest.newCreateFailedMessageRequest;
-import static uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageRequest.newSearchFailedMessageRequest;
+import static uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageRequest.searchMatchingAllCriteria;
 import static uk.gov.dwp.queue.triage.core.domain.SearchFailedMessageResponseMatcher.aFailedMessage;
 import static uk.gov.dwp.queue.triage.core.jms.FailedMessageListenerComponentTest.contains;
 import static uk.gov.dwp.queue.triage.id.FailedMessageId.newFailedMessageId;
@@ -55,7 +55,7 @@ public class ClassifyFailedMessageComponentTest extends BaseCoreComponentTest<Jm
         messageClassificationWhenStage.when().theMessageClassificationJobExecutes();
 
         searchFailedMessageStage.then().aSearch$WillContain$(
-                newSearchFailedMessageRequest().withBroker("some-broker"),
+                searchMatchingAllCriteria().withBroker("some-broker"),
                 contains(aFailedMessage()
                         .withFailedMessageId(equalTo(failedMessageId))
                         .withContent(equalTo("nuts")))
@@ -84,7 +84,7 @@ public class ClassifyFailedMessageComponentTest extends BaseCoreComponentTest<Jm
         messageClassificationWhenStage.when().theMessageClassificationJobExecutes();
 
         searchFailedMessageStage.then().aSearch$WillContain$(
-                newSearchFailedMessageRequest().withDestination("some-queue"),
+                searchMatchingAllCriteria().withDestination("some-queue"),
                 contains(aFailedMessage().withFailedMessageId(equalTo(failedMessageId)))
         );
     }

--- a/core/component-test/src/test/java/uk/gov/dwp/queue/triage/core/delete/DeleteFailedMessageComponentTest.java
+++ b/core/component-test/src/test/java/uk/gov/dwp/queue/triage/core/delete/DeleteFailedMessageComponentTest.java
@@ -8,7 +8,7 @@ import uk.gov.dwp.queue.triage.core.search.SearchFailedMessageStage;
 import uk.gov.dwp.queue.triage.id.FailedMessageId;
 
 import static uk.gov.dwp.queue.triage.core.client.CreateFailedMessageRequest.newCreateFailedMessageRequest;
-import static uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageRequest.newSearchFailedMessageRequest;
+import static uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageRequest.searchMatchingAllCriteria;
 import static uk.gov.dwp.queue.triage.core.search.SearchFailedMessageStage.noResults;
 
 public class DeleteFailedMessageComponentTest extends BaseCoreComponentTest<DeleteFailedMessageStage> {
@@ -28,7 +28,7 @@ public class DeleteFailedMessageComponentTest extends BaseCoreComponentTest<Dele
                 .exists();
 
         when().theFailedMessageWithId$IsDeleted(failedMessageId);
-        searchFailedMessageStage.and().aSearchIsRequested(newSearchFailedMessageRequest()
+        searchFailedMessageStage.and().aSearchIsRequested(searchMatchingAllCriteria()
                 .withBroker("broker-name")
                 .withDestination("queue-name")
         );

--- a/core/component-test/src/test/java/uk/gov/dwp/queue/triage/core/jms/FailedMessageListenerAdminComponentTest.java
+++ b/core/component-test/src/test/java/uk/gov/dwp/queue/triage/core/jms/FailedMessageListenerAdminComponentTest.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
-import static uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageRequest.newSearchFailedMessageRequest;
+import static uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageRequest.searchMatchingAllCriteria;
 import static uk.gov.dwp.queue.triage.core.domain.SearchFailedMessageResponseMatcher.aFailedMessage;
 
 public class FailedMessageListenerAdminComponentTest extends BaseCoreComponentTest<FailedMessageListenerAdminStage> {
@@ -32,14 +32,14 @@ public class FailedMessageListenerAdminComponentTest extends BaseCoreComponentTe
         jmsStage.when().aMessageWithContent$IsSentTo$OnBroker$("poison", "some-queue", "internal-broker");
 
         searchFailedMessageStage.then().aSearch$WillContain$(
-                newSearchFailedMessageRequest().withBroker("internal-broker"),
+                searchMatchingAllCriteria().withBroker("internal-broker"),
                 Matchers.emptyIterable()
         );
         when().aRequestIsMadeToStartTheMessageListenerForBroker$("internal-broker");
 
         then().theMessageListenerFor$Is$Running("internal-broker", true);
         searchFailedMessageStage.then().aSearch$WillContain$(
-                newSearchFailedMessageRequest().withBroker("internal-broker"),
+                searchMatchingAllCriteria().withBroker("internal-broker"),
                 contains(aFailedMessage()
                         .withBroker(equalTo("internal-broker"))
                         .withDestination(equalTo(Optional.of("some-queue")))

--- a/core/component-test/src/test/java/uk/gov/dwp/queue/triage/core/jms/FailedMessageListenerComponentTest.java
+++ b/core/component-test/src/test/java/uk/gov/dwp/queue/triage/core/jms/FailedMessageListenerComponentTest.java
@@ -15,7 +15,7 @@ import java.util.Arrays;
 import java.util.Optional;
 
 import static org.hamcrest.Matchers.equalTo;
-import static uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageRequest.newSearchFailedMessageRequest;
+import static uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageRequest.searchMatchingAllCriteria;
 import static uk.gov.dwp.queue.triage.core.domain.SearchFailedMessageResponseMatcher.aFailedMessage;
 
 public class FailedMessageListenerComponentTest extends BaseCoreComponentTest<JmsStage> {
@@ -32,7 +32,7 @@ public class FailedMessageListenerComponentTest extends BaseCoreComponentTest<Jm
         when().and().aMessageWithContent$IsSentTo$OnBroker$("elixir", "some-queue", "internal-broker");
 
         searchFailedMessageStage.then().aSearch$WillContain$(
-                newSearchFailedMessageRequest().withBroker("internal-broker"),
+                searchMatchingAllCriteria().withBroker("internal-broker"),
                 contains(aFailedMessage()
                         .withBroker(equalTo("internal-broker"))
                         .withDestination(equalTo(Optional.of("some-queue")))

--- a/core/resend/src/main/java/uk/gov/dwp/queue/triage/core/resend/ResendFailedMessageService.java
+++ b/core/resend/src/main/java/uk/gov/dwp/queue/triage/core/resend/ResendFailedMessageService.java
@@ -9,7 +9,7 @@ import uk.gov.dwp.queue.triage.core.search.FailedMessageSearchService;
 import java.util.function.Predicate;
 
 import static uk.gov.dwp.queue.triage.core.client.FailedMessageStatus.RESENDING;
-import static uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageRequest.newSearchFailedMessageRequest;
+import static uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageRequest.searchMatchingAllCriteria;
 
 public class ResendFailedMessageService {
 
@@ -33,7 +33,7 @@ public class ResendFailedMessageService {
     public void resendMessages() {
         LOGGER.debug("Resending FailedMessages to: {}", brokerName);
         failedMessageSearchService
-                .search(newSearchFailedMessageRequest()
+                .search(searchMatchingAllCriteria()
                         .withBroker(brokerName)
                         .withStatus(RESENDING)
                         .build())

--- a/core/resend/src/test/java/uk/gov/dwp/queue/triage/core/resend/ResendFailedMessageServiceTest.java
+++ b/core/resend/src/test/java/uk/gov/dwp/queue/triage/core/resend/ResendFailedMessageServiceTest.java
@@ -18,7 +18,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.dwp.queue.triage.core.client.FailedMessageStatus.RESENDING;
-import static uk.gov.dwp.queue.triage.core.domain.SearchFailedMessageRequestMatcher.aSearchRequest;
+import static uk.gov.dwp.queue.triage.core.domain.SearchFailedMessageRequestMatcher.aSearchRequestMatchingAllCriteria;
 
 public class ResendFailedMessageServiceTest {
 
@@ -38,7 +38,7 @@ public class ResendFailedMessageServiceTest {
 
     @Test
     public void successfullyResendFailedMessages() throws Exception {
-        SearchFailedMessageRequest searchRequest = argThat(new HamcrestArgumentMatcher<>(aSearchRequest()
+        SearchFailedMessageRequest searchRequest = argThat(new HamcrestArgumentMatcher<>(aSearchRequestMatchingAllCriteria()
                 .withBroker(equalTo(Optional.of(BROKER_NAME)))
                 .withStatusMatcher(contains(RESENDING))));
         when(failedMessageSearchService.search(searchRequest)).thenReturn(asList(failedMessage, anotherFailedMessage));

--- a/core/server/src/test/java/uk/gov/dwp/queue/triage/core/resource/search/FailedMessageSearchResourceTest.java
+++ b/core/server/src/test/java/uk/gov/dwp/queue/triage/core/resource/search/FailedMessageSearchResourceTest.java
@@ -13,7 +13,6 @@ import uk.gov.dwp.queue.triage.core.search.FailedMessageSearchService;
 import uk.gov.dwp.queue.triage.core.search.SearchFailedMessageResponseAdapter;
 import uk.gov.dwp.queue.triage.id.FailedMessageId;
 
-import javax.ws.rs.BadRequestException;
 import javax.ws.rs.NotFoundException;
 import java.util.Collection;
 import java.util.Optional;
@@ -27,7 +26,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
-import static uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageRequest.newSearchFailedMessageRequest;
 
 public class FailedMessageSearchResourceTest {
 

--- a/web/component-test/BUCK
+++ b/web/component-test/BUCK
@@ -4,8 +4,9 @@ java_library(
     deps = [
         '//common/id:queue-triage-common-id',
         '//common/jgiven:jgiven',
-        '//common/ldap-test-support:queue-traige-ldap-test-support',
+        '//common/ldap-test-support:queue-triage-ldap-test-support',
         '//core/client:queue-triage-core-client',
+        '//core/client-test-support:queue-triage-core-client-test-support',
         '//lib/selenide:selenide',
         '//lib/selenium:selenium-api',
         '//lib/spring:spring-boot-test',
@@ -28,6 +29,7 @@ java_test(
     srcs = glob(['src/test/java/**/*Test.java']),
     deps = [
         '//common/jgiven:jgiven',
+        '//core/client-test-support:queue-triage-core-client-test-support',
         "//lib/hibernate-validator:hibernate-validator",
         '//lib/selenide:selenide',
         '//lib/selenide:selenide-dependencies',

--- a/web/component-test/src/main/java/uk/gov/dwp/queue/triage/web/component/list/FailedMessageListThenStage.java
+++ b/web/component-test/src/main/java/uk/gov/dwp/queue/triage/web/component/list/FailedMessageListThenStage.java
@@ -1,0 +1,29 @@
+package uk.gov.dwp.queue.triage.web.component.list;
+
+import com.codeborne.selenide.Selenide;
+import org.openqa.selenium.By;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.dwp.queue.triage.id.FailedMessageId;
+import uk.gov.dwp.queue.triage.jgiven.ThenStage;
+
+import static com.codeborne.selenide.CollectionCondition.size;
+import static com.codeborne.selenide.Condition.exist;
+
+public class FailedMessageListThenStage extends ThenStage<FailedMessageListThenStage> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FailedMessageListThenStage.class);
+
+    public FailedMessageListThenStage theMessageListIsEmpty() {
+        LOGGER.debug("Asserting the MessageList is empty");
+        Selenide.$$(By.cssSelector("tr[recid]")).shouldHave(size(0));
+        return this;
+    }
+
+    public FailedMessageListThenStage theMessageListContainsAFailedMessageWithId(FailedMessageId failedMessageId) throws InterruptedException {
+        LOGGER.debug("Asserting FailedMessageId: {} is in the MessageList", failedMessageId);
+        Selenide.$(By.cssSelector("tr[recid='" + failedMessageId.toString() + "']")).should(exist);
+        return this;
+    }
+
+}

--- a/web/component-test/src/main/java/uk/gov/dwp/queue/triage/web/component/list/ListFailedMessagesStage.java
+++ b/web/component-test/src/main/java/uk/gov/dwp/queue/triage/web/component/list/ListFailedMessagesStage.java
@@ -5,6 +5,8 @@ import com.tngtech.jgiven.Stage;
 import com.tngtech.jgiven.annotation.ProvidedScenarioState;
 import com.tngtech.jgiven.integration.spring.JGivenStage;
 import org.mockito.Mockito;
+import org.mockito.hamcrest.MockitoHamcrest;
+import org.mockito.internal.hamcrest.HamcrestArgumentMatcher;
 import org.openqa.selenium.By;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -14,6 +16,7 @@ import uk.gov.dwp.queue.triage.core.client.SearchFailedMessageClient;
 import uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageRequest;
 import uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageResponse;
 import uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageResponse.SearchFailedMessageResponseBuilder;
+import uk.gov.dwp.queue.triage.core.domain.SearchFailedMessageRequestMatcher;
 import uk.gov.dwp.queue.triage.id.FailedMessageId;
 
 import java.util.Arrays;
@@ -64,6 +67,13 @@ public class ListFailedMessagesStage extends Stage<ListFailedMessagesStage> {
         return this;
     }
 
+    public ListFailedMessagesStage queueTriageCoreWillRespondTo(SearchFailedMessageRequestMatcher searchFailedMessageRequestMatcher,
+                                                                SearchFailedMessageResponse... failedMessages) {
+        Mockito.when(searchFailedMessageClient.search(MockitoHamcrest.argThat(searchFailedMessageRequestMatcher)))
+                .thenReturn(Arrays.asList(failedMessages));
+        return this;
+    }
+
     public ListFailedMessagesStage theUserHasNavigatedToTheFailedMessagesPage() {
         return theUserNavigatesToTheFailedMessagesPage();
     }
@@ -71,18 +81,6 @@ public class ListFailedMessagesStage extends Stage<ListFailedMessagesStage> {
     public ListFailedMessagesStage theUserNavigatesToTheFailedMessagesPage() {
         LOGGER.debug("Opening the ListFailedMessagePage");
         ListFailedMessagesPage.openListFailedMessagePage(environment);
-        return this;
-    }
-
-    public ListFailedMessagesStage theMessageListIsEmpty() {
-        LOGGER.debug("Asserting the MessageList is empty");
-        Selenide.$$(By.cssSelector("tr[recid]")).shouldHave(size(0));
-        return this;
-    }
-
-    public ListFailedMessagesStage theMessageListContainsAFailedMessageWithId(FailedMessageId failedMessageId) throws InterruptedException {
-        LOGGER.debug("Asserting FailedMessageId: {} is in the MessageList", failedMessageId);
-        Selenide.$(By.cssSelector("tr[recid='" + failedMessageId.toString() + "']")).should(exist);
         return this;
     }
 

--- a/web/component-test/src/main/java/uk/gov/dwp/queue/triage/web/component/search/SearchFailedMessageWhenStage.java
+++ b/web/component-test/src/main/java/uk/gov/dwp/queue/triage/web/component/search/SearchFailedMessageWhenStage.java
@@ -1,0 +1,38 @@
+package uk.gov.dwp.queue.triage.web.component.search;
+
+import com.codeborne.selenide.Condition;
+import com.codeborne.selenide.Selenide;
+import com.tngtech.jgiven.integration.spring.JGivenStage;
+import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.dwp.queue.triage.jgiven.WhenStage;
+
+@JGivenStage
+public class SearchFailedMessageWhenStage extends WhenStage<SearchFailedMessageWhenStage> {
+
+    private static Logger LOGGER = LoggerFactory.getLogger(SearchFailedMessageWhenStage.class);
+
+    public SearchFailedMessageWhenStage theUserSearchesFor(String searchText) {
+        LOGGER.debug("Searching for failedMessages containing any field equal to '{}'", searchText);
+        Selenide.$(By.id("grid_failedMessages_search_all"))
+                .sendKeys(searchText + Keys.RETURN);
+        return this;
+    }
+
+    public SearchFailedMessageWhenStage theUserSearchesForTheField$EqualTo$(String fieldName, String searchText) {
+        LOGGER.debug("Searching for failedMessages with '{}' equal to '{}'", fieldName, searchText);
+        Selenide.$(By.id("tb_failedMessages_toolbar_item_w2ui-search"))
+                .find(By.className("icon-search-down"))
+                .click();
+        Selenide.$(By.id("w2ui-overlay-failedMessages-searchFields"))
+                .findAll("td")
+                .findBy(Condition.text("Broker"))
+                .parent()
+                .click();
+        Selenide.$(By.id("grid_failedMessages_search_all"))
+                .sendKeys(searchText + Keys.RETURN);
+        return this;
+    }
+}

--- a/web/component-test/src/test/java/uk/gov/dwp/queue/triage/web/component/list/ViewFailedMessagesComponentTest.java
+++ b/web/component-test/src/test/java/uk/gov/dwp/queue/triage/web/component/list/ViewFailedMessagesComponentTest.java
@@ -4,6 +4,7 @@ import com.tngtech.jgiven.annotation.ScenarioStage;
 import org.junit.Test;
 import uk.gov.dwp.queue.triage.id.FailedMessageId;
 import uk.gov.dwp.queue.triage.web.component.SimpleBaseWebComponentTest;
+import uk.gov.dwp.queue.triage.web.component.WebComponentTest;
 import uk.gov.dwp.queue.triage.web.component.login.LoginGivenStage;
 
 import java.time.Instant;
@@ -13,7 +14,7 @@ import static java.time.temporal.ChronoUnit.HOURS;
 import static java.time.temporal.ChronoUnit.MINUTES;
 import static uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageResponse.newSearchFailedMessageResponse;
 
-public class ViewFailedMessagesComponentTest extends SimpleBaseWebComponentTest<ListFailedMessagesStage> {
+public class ViewFailedMessagesComponentTest extends WebComponentTest<ListFailedMessagesStage, ListFailedMessagesStage, FailedMessageListThenStage> {
 
     private static final FailedMessageId FAILED_MESSAGE_ID_1 = FailedMessageId.newFailedMessageId();
     private static final FailedMessageId FAILED_MESSAGE_ID_2 = FailedMessageId.newFailedMessageId();

--- a/web/component-test/src/test/java/uk/gov/dwp/queue/triage/web/component/search/SearchFailedMessageComponentTest.java
+++ b/web/component-test/src/test/java/uk/gov/dwp/queue/triage/web/component/search/SearchFailedMessageComponentTest.java
@@ -1,0 +1,63 @@
+package uk.gov.dwp.queue.triage.web.component.search;
+
+import com.tngtech.jgiven.annotation.ScenarioStage;
+import org.junit.Test;
+import uk.gov.dwp.queue.triage.id.FailedMessageId;
+import uk.gov.dwp.queue.triage.web.component.WebComponentTest;
+import uk.gov.dwp.queue.triage.web.component.list.FailedMessageListThenStage;
+import uk.gov.dwp.queue.triage.web.component.list.ListFailedMessagesStage;
+import uk.gov.dwp.queue.triage.web.component.login.LoginGivenStage;
+
+import java.util.Optional;
+
+import static uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageResponse.newSearchFailedMessageResponse;
+import static uk.gov.dwp.queue.triage.core.domain.SearchFailedMessageRequestMatcher.aSearchRequestMatchingAnyCriteria;
+
+public class SearchFailedMessageComponentTest extends WebComponentTest<ListFailedMessagesStage, SearchFailedMessageWhenStage, FailedMessageListThenStage> {
+
+    private static final FailedMessageId FAILED_MESSAGE_ID_1 = FailedMessageId.newFailedMessageId();
+
+    @ScenarioStage
+    private LoginGivenStage loginGivenStage;
+
+    @Test
+    public void searchAllFields() throws Exception {
+        loginGivenStage.given().theUserHasSuccessfullyLoggedOn();
+        given().and().theUserNavigatesToTheFailedMessagesPage();
+        given().and().queueTriageCoreWillRespondTo(
+                aSearchRequestMatchingAnyCriteria()
+                        .withBroker("some-text")
+                        .withContent("some-text")
+                        .withDestination("some-text"),
+                newSearchFailedMessageResponse()
+                        .withFailedMessageId(FAILED_MESSAGE_ID_1)
+                        .withBroker("main-broker")
+                        .withDestination(Optional.of("queue-name"))
+                        .withContent("This message contains some-text")
+                        .build()
+        );
+
+        when().theUserSearchesFor("some-text");
+
+        then().theMessageListContainsAFailedMessageWithId(FAILED_MESSAGE_ID_1);
+    }
+
+    @Test
+    public void searchForASpecificField() throws Exception {
+        loginGivenStage.given().theUserHasSuccessfullyLoggedOn();
+        given().and().theUserNavigatesToTheFailedMessagesPage();
+        given().and().queueTriageCoreWillRespondTo(
+                aSearchRequestMatchingAnyCriteria().withBroker("main-broker"),
+                newSearchFailedMessageResponse()
+                        .withFailedMessageId(FAILED_MESSAGE_ID_1)
+                        .withBroker("main-broker")
+                        .withDestination(Optional.of("queue-name"))
+                        .withContent("This message contains some-text")
+                        .build()
+        );
+
+        when().theUserSearchesForTheField$EqualTo$("Broker", "main-broker");
+
+        then().theMessageListContainsAFailedMessageWithId(FAILED_MESSAGE_ID_1);
+    }
+}

--- a/web/server/src/main/java/uk/gov/dwp/queue/triage/web/server/configuration/ControllerConfiguration.java
+++ b/web/server/src/main/java/uk/gov/dwp/queue/triage/web/server/configuration/ControllerConfiguration.java
@@ -14,8 +14,10 @@ import uk.gov.dwp.queue.triage.web.server.api.FailedMessageChangeResource;
 import uk.gov.dwp.queue.triage.web.server.api.resend.ResendFailedMessageResource;
 import uk.gov.dwp.queue.triage.web.server.home.HomeController;
 import uk.gov.dwp.queue.triage.web.server.list.FailedMessageListController;
-import uk.gov.dwp.queue.triage.web.server.list.FailedMessageListItemAdapter;
+import uk.gov.dwp.queue.triage.web.server.search.FailedMessageListItemAdapter;
 import uk.gov.dwp.queue.triage.web.server.api.LabelExtractor;
+import uk.gov.dwp.queue.triage.web.server.search.SearchFailedMessageController;
+import uk.gov.dwp.queue.triage.web.server.search.SearchFailedMessageRequestAdapter;
 import uk.gov.dwp.queue.triage.web.server.login.AuthenticationExceptionAdapter;
 import uk.gov.dwp.queue.triage.web.server.login.LoginController;
 
@@ -38,10 +40,16 @@ public class ControllerConfiguration {
     }
 
     @Bean
-    public FailedMessageListController failedMessageListController(ResourceRegistry resourceRegistry,
-                                                                   SearchFailedMessageClient searchFailedMessageClient) {
-        return resourceRegistry.add(new FailedMessageListController(
+    public FailedMessageListController failedMessageListController(ResourceRegistry resourceRegistry) {
+        return resourceRegistry.add(new FailedMessageListController());
+    }
+
+    @Bean
+    public SearchFailedMessageController searchFailedMessageController(ResourceRegistry resourceRegistry,
+                                                                       SearchFailedMessageClient searchFailedMessageClient) {
+        return resourceRegistry.add(new SearchFailedMessageController(
                 searchFailedMessageClient,
+                new SearchFailedMessageRequestAdapter(),
                 new FailedMessageListItemAdapter()
         ));
     }
@@ -59,7 +67,7 @@ public class ControllerConfiguration {
 
     @Bean
     public ResendFailedMessageResource resendFailedMessageResource(ResourceRegistry resourceRegistry,
-                                                            ResendFailedMessageClient resendFailedMessageClient) {
+                                                                   ResendFailedMessageClient resendFailedMessageClient) {
         return resourceRegistry.add(new ResendFailedMessageResource(resendFailedMessageClient));
     }
 }

--- a/web/server/src/main/java/uk/gov/dwp/queue/triage/web/server/list/FailedMessageListController.java
+++ b/web/server/src/main/java/uk/gov/dwp/queue/triage/web/server/list/FailedMessageListController.java
@@ -1,55 +1,20 @@
 package uk.gov.dwp.queue.triage.web.server.list;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import uk.gov.dwp.queue.triage.core.client.SearchFailedMessageClient;
-import uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageResponse;
-import uk.gov.dwp.queue.triage.web.server.w2ui.BaseW2UIRequest;
-import uk.gov.dwp.queue.triage.web.server.w2ui.W2UIResponse;
-
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
-import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
-import java.util.Collection;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.MediaType.TEXT_HTML;
-import static uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageRequest.newSearchFailedMessageRequest;
 
 @Path("/failed-messages")
 public class FailedMessageListController {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(FailedMessageListController.class);
-    private final SearchFailedMessageClient searchFailedMessageClient;
-    private final FailedMessageListItemAdapter failedMessageListItemAdapter;
-
-    public FailedMessageListController(SearchFailedMessageClient searchFailedMessageClient,
-                                       FailedMessageListItemAdapter failedMessageListItemAdapter) {
-        this.searchFailedMessageClient = searchFailedMessageClient;
-        this.failedMessageListItemAdapter = failedMessageListItemAdapter;
-    }
 
     @GET
     @Consumes(APPLICATION_JSON)
     @Produces(TEXT_HTML)
     public FailedMessageListPage getFailedMessages() {
         return new FailedMessageListPage();
-    }
-
-    @POST
-    @Path("/data")
-    @Consumes(APPLICATION_JSON)
-    @Produces(APPLICATION_JSON)
-    public W2UIResponse<FailedMessageListItem> getData(BaseW2UIRequest request) {
-        LOGGER.info("Getting data");
-        Collection<SearchFailedMessageResponse> failedMessages = searchFailedMessageClient
-                .search(newSearchFailedMessageRequest().build());
-        return new W2UIResponse<>(
-                "success",
-                failedMessages.size(),
-                failedMessageListItemAdapter.adapt(failedMessages)
-        );
     }
 }

--- a/web/server/src/main/java/uk/gov/dwp/queue/triage/web/server/search/FailedMessageListItemAdapter.java
+++ b/web/server/src/main/java/uk/gov/dwp/queue/triage/web/server/search/FailedMessageListItemAdapter.java
@@ -1,6 +1,7 @@
-package uk.gov.dwp.queue.triage.web.server.list;
+package uk.gov.dwp.queue.triage.web.server.search;
 
 import uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageResponse;
+import uk.gov.dwp.queue.triage.web.server.list.FailedMessageListItem;
 
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;

--- a/web/server/src/main/java/uk/gov/dwp/queue/triage/web/server/search/SearchFailedMessageController.java
+++ b/web/server/src/main/java/uk/gov/dwp/queue/triage/web/server/search/SearchFailedMessageController.java
@@ -1,0 +1,44 @@
+package uk.gov.dwp.queue.triage.web.server.search;
+
+import uk.gov.dwp.queue.triage.core.client.SearchFailedMessageClient;
+import uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageResponse;
+import uk.gov.dwp.queue.triage.web.server.list.FailedMessageListItem;
+import uk.gov.dwp.queue.triage.web.server.w2ui.W2UIResponse;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import java.util.Collection;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+@Path("/failed-messages/search")
+public class SearchFailedMessageController {
+
+    private final SearchFailedMessageClient searchFailedMessageClient;
+    private final SearchFailedMessageRequestAdapter searchFailedMessageRequestAdapter;
+    private final FailedMessageListItemAdapter failedMessageListItemAdapter;
+
+    public SearchFailedMessageController(SearchFailedMessageClient searchFailedMessageClient,
+                                         SearchFailedMessageRequestAdapter searchFailedMessageRequestAdapter,
+                                         FailedMessageListItemAdapter failedMessageListItemAdapter) {
+        this.searchFailedMessageClient = searchFailedMessageClient;
+        this.searchFailedMessageRequestAdapter = searchFailedMessageRequestAdapter;
+        this.failedMessageListItemAdapter = failedMessageListItemAdapter;
+    }
+
+    @POST
+    @Consumes(APPLICATION_JSON)
+    @Produces(APPLICATION_JSON)
+    public W2UIResponse<FailedMessageListItem> search(SearchW2UIRequest request) {
+        Collection<SearchFailedMessageResponse> failedMessages = searchFailedMessageClient.search(
+                searchFailedMessageRequestAdapter.adapt(request)
+        );
+        return new W2UIResponse<>(
+                "success",
+                failedMessages.size(),
+                failedMessageListItemAdapter.adapt(failedMessages)
+        );
+    }
+}

--- a/web/server/src/main/java/uk/gov/dwp/queue/triage/web/server/search/SearchFailedMessageRequestAdapter.java
+++ b/web/server/src/main/java/uk/gov/dwp/queue/triage/web/server/search/SearchFailedMessageRequestAdapter.java
@@ -1,0 +1,12 @@
+package uk.gov.dwp.queue.triage.web.server.search;
+
+import uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageRequest;
+
+import static uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageRequest.newSearchFailedMessageRequest;
+
+public class SearchFailedMessageRequestAdapter {
+
+    public SearchFailedMessageRequest adapt(SearchW2UIRequest request) {
+        return newSearchFailedMessageRequest().build();
+    }
+}

--- a/web/server/src/main/java/uk/gov/dwp/queue/triage/web/server/search/SearchFailedMessageRequestAdapter.java
+++ b/web/server/src/main/java/uk/gov/dwp/queue/triage/web/server/search/SearchFailedMessageRequestAdapter.java
@@ -1,12 +1,18 @@
 package uk.gov.dwp.queue.triage.web.server.search;
 
 import uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageRequest;
+import uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageRequest.SearchFailedMessageRequestBuilder;
+import uk.gov.dwp.queue.triage.web.server.search.SearchW2UIRequest.Criteria;
 
-import static uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageRequest.newSearchFailedMessageRequest;
+import static uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageRequest.searchMatchingAnyCriteria;
 
 public class SearchFailedMessageRequestAdapter {
 
     public SearchFailedMessageRequest adapt(SearchW2UIRequest request) {
-        return newSearchFailedMessageRequest().build();
+        SearchFailedMessageRequestBuilder searchFailedMessageRequestBuilder = searchMatchingAnyCriteria();
+        for (Criteria criteria : request.getSearchCriteria()) {
+            criteria.addToSearchRequest(searchFailedMessageRequestBuilder);
+        }
+        return searchFailedMessageRequestBuilder.build();
     }
 }

--- a/web/server/src/main/java/uk/gov/dwp/queue/triage/web/server/search/SearchW2UIRequest.java
+++ b/web/server/src/main/java/uk/gov/dwp/queue/triage/web/server/search/SearchW2UIRequest.java
@@ -1,0 +1,122 @@
+package uk.gov.dwp.queue.triage.web.server.search;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.dwp.queue.triage.web.server.w2ui.BaseW2UIRequest;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SearchW2UIRequest extends BaseW2UIRequest {
+
+    private final List<Criteria> searchCriteria;
+    private final Logic searchLogic;
+
+    public SearchW2UIRequest(@JsonProperty("cmd") String cmd,
+                             @JsonProperty("limit") Integer limit,
+                             @JsonProperty("offset") Integer offset,
+                             @JsonProperty("selected") List<String> selected,
+                             @JsonProperty(value = "search", defaultValue = "[]") List<Criteria> searchCriteria,
+                             @JsonProperty("searchLogic") Logic searchLogic) {
+        super(cmd, limit, offset, selected);
+        this.searchCriteria = searchCriteria;
+        this.searchLogic = searchLogic;
+    }
+
+    public List<Criteria> getSearchCriteria() {
+        return searchCriteria;
+    }
+
+    public Logic getSearchLogic() {
+        return searchLogic;
+    }
+
+    public static class Criteria {
+
+        private final Field field;
+        private final String type;
+        private final Operator operator;
+        private final String value;
+
+        public Criteria(@JsonProperty("field") Field field,
+                        @JsonProperty("type") String type,
+                        @JsonProperty("operator") Operator operator,
+                        @JsonProperty("value") String value) {
+            this.field = field;
+            this.type = type;
+            this.operator = operator;
+            this.value = value;
+        }
+
+        public Field getField() {
+            return field;
+        }
+
+        public String getType() {
+            return type;
+        }
+
+        public Operator getOperator() {
+            return operator;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        public enum Field {
+            BROKER("broker"),
+            DESTINATION("destination"),
+            LABELS("labels"),
+            CONTENT("content");
+
+            private final String field;
+            private static final Map<String, Field> MAPPING = Stream.of(values()).collect(Collectors.toMap(Field::getField, Function.identity()));
+
+            Field(String field) {
+                this.field = field;
+            }
+
+            @JsonCreator
+            public static Field of(String field) {
+                return MAPPING.get(field);
+            }
+
+            public String getField() {
+                return field;
+            }
+        }
+
+        public enum Operator {
+            BEGINS("begins"),
+            CONTAINS("contains"),
+            ENDS("ends"),
+            IS("is");
+
+            private final String operator;
+            private static final Map<String, Operator> MAPPING = Stream.of(values()).collect(Collectors.toMap(Operator::getOperator, Function.identity()));
+
+            Operator(String operator) {
+                this.operator = operator;
+            }
+
+            @JsonCreator
+            public static Operator of(String operator) {
+                return MAPPING.get(operator);
+            }
+
+            public String getOperator() {
+                return operator;
+            }
+        }
+    }
+
+    public enum Logic {
+        AND, OR
+    }
+}

--- a/web/server/src/main/resources/mustache/list.mustache
+++ b/web/server/src/main/resources/mustache/list.mustache
@@ -25,19 +25,20 @@
             show: {
                 selectColumn: true,
                 toolbar: true,
-                toolbarSearch: true,
+                toolbarSearch: false,
                 toolbarDelete: true,
                 toolbarSave: true
             },
             multiSearch: true,
+            textSearch: 'contains',
             columns: [
                 { field: 'recid', caption: 'Failed Message Id', size: '220px', sortable: true },
                 { field: 'broker', caption: 'Broker', size: '10%', sortable: true, searchable: true },
                 { field: 'destination', caption: 'Queue', size: '10%', sortable: true, searchable: true },
                 { field: 'sentDateTime', caption: 'Originally Sent', size: '160px', sortable: true },
                 { field: 'failedDateTime', caption: 'Failed', size: '160px', sortable: true },
-                { field: 'labels', caption: 'Labels', size: '20%', editable: { type: 'text' }, searchable: true },
-                { field: 'content', caption: 'Content', size: '80%', sortable: true, searchable: true },
+                { field: 'labels', caption: 'Labels', size: '20%', editable: { type: 'text' } },
+                { field: 'content', caption: 'Content', size: '80%', sortable: true, searchable: true }
             ],
             onSelect: function(event) {
                 event.onComplete = function() {

--- a/web/server/src/main/resources/mustache/list.mustache
+++ b/web/server/src/main/resources/mustache/list.mustache
@@ -17,7 +17,7 @@
         $('#failed-message-list-grid').w2grid({
             name: 'failedMessages',
             url: {
-                get: '/web/failed-messages/data',
+                get: '/web/failed-messages/search',
                 remove: '/web/api/failed-messages/delete',
                 resend: '/web/api/failed-messages/resend',
                 save: '/web/api/failed-messages/labels'
@@ -25,18 +25,19 @@
             show: {
                 selectColumn: true,
                 toolbar: true,
-                toolbarSearch: false,
+                toolbarSearch: true,
                 toolbarDelete: true,
                 toolbarSave: true
             },
+            multiSearch: true,
             columns: [
                 { field: 'recid', caption: 'Failed Message Id', size: '220px', sortable: true },
-                { field: 'broker', caption: 'Broker', size: '10%', sortable: true },
-                { field: 'destination', caption: 'Queue', size: '10%', sortable: true },
+                { field: 'broker', caption: 'Broker', size: '10%', sortable: true, searchable: true },
+                { field: 'destination', caption: 'Queue', size: '10%', sortable: true, searchable: true },
                 { field: 'sentDateTime', caption: 'Originally Sent', size: '160px', sortable: true },
                 { field: 'failedDateTime', caption: 'Failed', size: '160px', sortable: true },
-                { field: 'labels', caption: 'Labels', size: '20%', editable: { type: 'text' } },
-                { field: 'content', caption: 'Content', size: '80%', sortable: true },
+                { field: 'labels', caption: 'Labels', size: '20%', editable: { type: 'text' }, searchable: true },
+                { field: 'content', caption: 'Content', size: '80%', sortable: true, searchable: true },
             ],
             onSelect: function(event) {
                 event.onComplete = function() {

--- a/web/server/src/test/java/uk/gov/dwp/queue/triage/web/server/list/FailedMessageListItemAdapterTest.java
+++ b/web/server/src/test/java/uk/gov/dwp/queue/triage/web/server/list/FailedMessageListItemAdapterTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 import uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageResponse;
 import uk.gov.dwp.queue.triage.id.FailedMessageId;
 import uk.gov.dwp.queue.triage.jackson.configuration.JacksonConfiguration;
+import uk.gov.dwp.queue.triage.web.server.search.FailedMessageListItemAdapter;
 
 import java.time.Instant;
 import java.time.LocalDate;
@@ -20,7 +21,6 @@ import static java.time.ZoneOffset.UTC;
 import static java.time.temporal.ChronoField.MILLI_OF_SECOND;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
 import static org.valid4j.matchers.jsonpath.JsonPathMatchers.hasJsonPath;

--- a/web/server/src/test/java/uk/gov/dwp/queue/triage/web/server/list/SearchW2UIRequestTest.java
+++ b/web/server/src/test/java/uk/gov/dwp/queue/triage/web/server/list/SearchW2UIRequestTest.java
@@ -1,0 +1,131 @@
+package uk.gov.dwp.queue.triage.web.server.list;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+import org.junit.Test;
+import uk.gov.dwp.queue.triage.jackson.configuration.JacksonConfiguration;
+import uk.gov.dwp.queue.triage.web.server.search.SearchW2UIRequest;
+import uk.gov.dwp.queue.triage.web.server.search.SearchW2UIRequest.Criteria;
+import uk.gov.dwp.queue.triage.web.server.search.SearchW2UIRequest.Criteria.Field;
+import uk.gov.dwp.queue.triage.web.server.search.SearchW2UIRequest.Criteria.Operator;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.isA;
+import static uk.gov.dwp.queue.triage.web.server.search.SearchW2UIRequest.Criteria.Field.BROKER;
+import static uk.gov.dwp.queue.triage.web.server.search.SearchW2UIRequest.Criteria.Field.CONTENT;
+import static uk.gov.dwp.queue.triage.web.server.search.SearchW2UIRequest.Criteria.Field.DESTINATION;
+import static uk.gov.dwp.queue.triage.web.server.search.SearchW2UIRequest.Criteria.Field.LABELS;
+import static uk.gov.dwp.queue.triage.web.server.search.SearchW2UIRequest.Criteria.Operator.BEGINS;
+import static uk.gov.dwp.queue.triage.web.server.search.SearchW2UIRequest.Criteria.Operator.CONTAINS;
+import static uk.gov.dwp.queue.triage.web.server.search.SearchW2UIRequest.Criteria.Operator.ENDS;
+import static uk.gov.dwp.queue.triage.web.server.search.SearchW2UIRequest.Criteria.Operator.IS;
+import static uk.gov.dwp.queue.triage.web.server.search.SearchW2UIRequest.Logic.OR;
+import static uk.gov.dwp.queue.triage.web.server.list.SearchW2UIRequestTest.CriteriaMatcher.criteria;
+
+public class SearchW2UIRequestTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = new JacksonConfiguration().objectMapper();
+
+    @Test
+    public void canDeserialiseSearchW2UIRequest() throws Exception {
+        SearchW2UIRequest searchW2UIRequest = OBJECT_MAPPER.readValue("{\n" +
+                "  \"cmd\": \"get\",\n" +
+                "  \"selected\": [],\n" +
+                "  \"limit\": 100,\n" +
+                "  \"offset\": 0,\n" +
+                "  \"search\": [\n" +
+                "    {\n" +
+                "      \"field\": \"broker\",\n" +
+                "      \"type\": \"text\",\n" +
+                "      \"operator\": \"begins\",\n" +
+                "      \"value\": \"Lorem\"\n" +
+                "    },\n" +
+                "    {\n" +
+                "      \"field\": \"destination\",\n" +
+                "      \"type\": \"text\",\n" +
+                "      \"operator\": \"contains\",\n" +
+                "      \"value\": \"ipsum\"\n" +
+                "    },\n" +
+                "    {\n" +
+                "      \"field\": \"labels\",\n" +
+                "      \"type\": \"text\",\n" +
+                "      \"operator\": \"ends\",\n" +
+                "      \"value\": \"dolor\"\n" +
+                "    },\n" +
+                "    {\n" +
+                "      \"field\": \"content\",\n" +
+                "      \"type\": \"text\",\n" +
+                "      \"operator\": \"is\",\n" +
+                "      \"value\": \"sit\"\n" +
+                "    }\n" +
+                "  ],\n" +
+                "  \"searchLogic\": \"OR\"\n" +
+                "}", SearchW2UIRequest.class);
+
+        assertThat(searchW2UIRequest.getSearchLogic(), equalTo(OR));
+        assertThat(searchW2UIRequest.getSearchCriteria(), contains(
+                criteria().withField(BROKER).withOperator(BEGINS).withValue("Lorem"),
+                criteria().withField(DESTINATION).withOperator(CONTAINS).withValue("ipsum"),
+                criteria().withField(LABELS).withOperator(ENDS).withValue("dolor"),
+                criteria().withField(CONTENT).withOperator(IS).withValue("sit")
+        ));
+    }
+
+    public static class CriteriaMatcher extends TypeSafeMatcher<Criteria> {
+
+        private Matcher<Field> field = isA(Field.class);
+        private Matcher<String> type = equalTo("text");
+        private Matcher<Operator> operator = isA(Operator.class);
+        private Matcher<String> value = isA(String.class);
+
+        private CriteriaMatcher() {
+        }
+
+        public static CriteriaMatcher criteria() {
+            return new CriteriaMatcher();
+        }
+
+        public CriteriaMatcher withField(Field field) {
+            this.field = equalTo(field);
+            return this;
+        }
+
+        public CriteriaMatcher withType(String type) {
+            this.type = equalTo(type);
+            return this;
+        }
+
+        public CriteriaMatcher withOperator(Operator operator) {
+            this.operator = equalTo(operator);
+            return this;
+        }
+
+        public CriteriaMatcher withValue(String value) {
+            this.value = equalTo(value);
+            return this;
+        }
+
+        @Override
+        protected boolean matchesSafely(Criteria criteria) {
+            return field.matches(criteria.getField()) &&
+                    type.matches(criteria.getType()) &&
+                    operator.matches(criteria.getOperator()) &&
+                    value.matches(criteria.getValue())
+                    ;
+        }
+
+        @Override
+        public void describeTo(Description description) {
+            description
+                    .appendText("field ").appendDescriptionOf(field)
+                    .appendText(" type ").appendDescriptionOf(type)
+                    .appendText(" operator ").appendDescriptionOf(operator)
+                    .appendText(" value ").appendDescriptionOf(value)
+                    ;
+        }
+    }
+}

--- a/web/server/src/test/java/uk/gov/dwp/queue/triage/web/server/list/SearchW2UIRequestTest.java
+++ b/web/server/src/test/java/uk/gov/dwp/queue/triage/web/server/list/SearchW2UIRequestTest.java
@@ -15,16 +15,14 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.isA;
+import static uk.gov.dwp.queue.triage.web.server.list.SearchW2UIRequestTest.CriteriaMatcher.criteria;
 import static uk.gov.dwp.queue.triage.web.server.search.SearchW2UIRequest.Criteria.Field.BROKER;
 import static uk.gov.dwp.queue.triage.web.server.search.SearchW2UIRequest.Criteria.Field.CONTENT;
 import static uk.gov.dwp.queue.triage.web.server.search.SearchW2UIRequest.Criteria.Field.DESTINATION;
-import static uk.gov.dwp.queue.triage.web.server.search.SearchW2UIRequest.Criteria.Field.LABELS;
 import static uk.gov.dwp.queue.triage.web.server.search.SearchW2UIRequest.Criteria.Operator.BEGINS;
 import static uk.gov.dwp.queue.triage.web.server.search.SearchW2UIRequest.Criteria.Operator.CONTAINS;
 import static uk.gov.dwp.queue.triage.web.server.search.SearchW2UIRequest.Criteria.Operator.ENDS;
-import static uk.gov.dwp.queue.triage.web.server.search.SearchW2UIRequest.Criteria.Operator.IS;
 import static uk.gov.dwp.queue.triage.web.server.search.SearchW2UIRequest.Logic.OR;
-import static uk.gov.dwp.queue.triage.web.server.list.SearchW2UIRequestTest.CriteriaMatcher.criteria;
 
 public class SearchW2UIRequestTest {
 
@@ -51,16 +49,10 @@ public class SearchW2UIRequestTest {
                 "      \"value\": \"ipsum\"\n" +
                 "    },\n" +
                 "    {\n" +
-                "      \"field\": \"labels\",\n" +
+                "      \"field\": \"content\",\n" +
                 "      \"type\": \"text\",\n" +
                 "      \"operator\": \"ends\",\n" +
                 "      \"value\": \"dolor\"\n" +
-                "    },\n" +
-                "    {\n" +
-                "      \"field\": \"content\",\n" +
-                "      \"type\": \"text\",\n" +
-                "      \"operator\": \"is\",\n" +
-                "      \"value\": \"sit\"\n" +
                 "    }\n" +
                 "  ],\n" +
                 "  \"searchLogic\": \"OR\"\n" +
@@ -70,15 +62,13 @@ public class SearchW2UIRequestTest {
         assertThat(searchW2UIRequest.getSearchCriteria(), contains(
                 criteria().withField(BROKER).withOperator(BEGINS).withValue("Lorem"),
                 criteria().withField(DESTINATION).withOperator(CONTAINS).withValue("ipsum"),
-                criteria().withField(LABELS).withOperator(ENDS).withValue("dolor"),
-                criteria().withField(CONTENT).withOperator(IS).withValue("sit")
+                criteria().withField(CONTENT).withOperator(ENDS).withValue("dolor")
         ));
     }
 
     public static class CriteriaMatcher extends TypeSafeMatcher<Criteria> {
 
         private Matcher<Field> field = isA(Field.class);
-        private Matcher<String> type = equalTo("text");
         private Matcher<Operator> operator = isA(Operator.class);
         private Matcher<String> value = isA(String.class);
 
@@ -91,11 +81,6 @@ public class SearchW2UIRequestTest {
 
         public CriteriaMatcher withField(Field field) {
             this.field = equalTo(field);
-            return this;
-        }
-
-        public CriteriaMatcher withType(String type) {
-            this.type = equalTo(type);
             return this;
         }
 
@@ -112,7 +97,6 @@ public class SearchW2UIRequestTest {
         @Override
         protected boolean matchesSafely(Criteria criteria) {
             return field.matches(criteria.getField()) &&
-                    type.matches(criteria.getType()) &&
                     operator.matches(criteria.getOperator()) &&
                     value.matches(criteria.getValue())
                     ;
@@ -122,7 +106,6 @@ public class SearchW2UIRequestTest {
         public void describeTo(Description description) {
             description
                     .appendText("field ").appendDescriptionOf(field)
-                    .appendText(" type ").appendDescriptionOf(type)
                     .appendText(" operator ").appendDescriptionOf(operator)
                     .appendText(" value ").appendDescriptionOf(value)
                     ;

--- a/web/server/src/test/java/uk/gov/dwp/queue/triage/web/server/search/SearchFailedMessageRequestAdapterTest.java
+++ b/web/server/src/test/java/uk/gov/dwp/queue/triage/web/server/search/SearchFailedMessageRequestAdapterTest.java
@@ -1,0 +1,49 @@
+package uk.gov.dwp.queue.triage.web.server.search;
+
+import org.junit.Test;
+import uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageRequest;
+import uk.gov.dwp.queue.triage.web.server.search.SearchW2UIRequest.Criteria;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.gov.dwp.queue.triage.core.domain.SearchFailedMessageRequestMatcher.aSearchRequestMatchingAnyCriteria;
+
+public class SearchFailedMessageRequestAdapterTest {
+
+    private final SearchW2UIRequest searchW2UIRequest = mock(SearchW2UIRequest.class);
+    private final SearchFailedMessageRequestAdapter underTest = new SearchFailedMessageRequestAdapter();
+
+    @Test
+    public void searchWithMultipleCriteria() throws Exception {
+        when(searchW2UIRequest.getSearchCriteria()).thenReturn(Arrays.asList(
+                new Criteria(Criteria.Field.BROKER, Criteria.Operator.BEGINS, "Lorem"),
+                new Criteria(Criteria.Field.CONTENT, Criteria.Operator.ENDS, "Ipsum"),
+                new Criteria(Criteria.Field.DESTINATION, Criteria.Operator.CONTAINS, "Dolor")
+        ));
+
+        SearchFailedMessageRequest request = underTest.adapt(searchW2UIRequest);
+
+        assertThat(request, aSearchRequestMatchingAnyCriteria()
+                .withBroker("Lorem")
+                .withContent("Ipsum")
+                .withDestination("Dolor"));
+    }
+
+    @Test
+    public void searchWithNoCriteria() throws Exception {
+        when(searchW2UIRequest.getSearchCriteria()).thenReturn(Collections.emptyList());
+
+        SearchFailedMessageRequest request = underTest.adapt(searchW2UIRequest);
+
+        assertThat(request, aSearchRequestMatchingAnyCriteria()
+                .withBroker(equalTo(Optional.empty()))
+                .withContent(equalTo(Optional.empty()))
+                .withDestination(equalTo(Optional.empty())));
+    }
+}


### PR DESCRIPTION
Added the ability from the web front-end to search by:
- `broker`
- `destination`
- `content`

As documented in the test: `SearchFailedMessageComponentTest` is is possible to search by individual field or for ALL fields.  The current implementation searches using "contains" for `content` and "equal to" for `destination` and `broker`