### PR TITLE
#88: Rename FailedMessageStatus to StatusHistoryEvent

### DIFF
--- a/core/dao-mongo/src/main/java/uk/gov/dwp/queue/triage/core/dao/mongo/FailedMessageConverter.java
+++ b/core/dao-mongo/src/main/java/uk/gov/dwp/queue/triage/core/dao/mongo/FailedMessageConverter.java
@@ -6,7 +6,7 @@ import com.mongodb.DBObject;
 import uk.gov.dwp.queue.triage.core.dao.ObjectConverter;
 import uk.gov.dwp.queue.triage.core.domain.Destination;
 import uk.gov.dwp.queue.triage.core.domain.FailedMessage;
-import uk.gov.dwp.queue.triage.core.domain.FailedMessageStatus;
+import uk.gov.dwp.queue.triage.core.domain.StatusHistoryEvent;
 import uk.gov.dwp.queue.triage.id.FailedMessageId;
 
 import java.time.Instant;
@@ -31,15 +31,15 @@ public class FailedMessageConverter implements DBObjectWithIdConverter<FailedMes
     public static final String LABELS = "labels";
 
     private final DBObjectConverter<Destination> destinationDBObjectMapper;
-    private final DBObjectConverter<FailedMessageStatus> failedMessageStatusDBObjectMapper;
+    private final DBObjectConverter<StatusHistoryEvent> statusHistoryEventDBObjectMapper;
     private final ObjectConverter<Map<String, Object>, String> propertiesMongoMapper;
 
     public FailedMessageConverter(DBObjectConverter<Destination> destinationDBObjectMapper,
-                                  DBObjectConverter<FailedMessageStatus> failedMessageStatusDBObjectMapper,
+                                  DBObjectConverter<StatusHistoryEvent> statusHistoryEventDBObjectMapper,
                                   ObjectConverter<Map<String, Object>, String> propertiesMongoMapper) {
         this.destinationDBObjectMapper = destinationDBObjectMapper;
         this.propertiesMongoMapper = propertiesMongoMapper;
-        this.failedMessageStatusDBObjectMapper = failedMessageStatusDBObjectMapper;
+        this.statusHistoryEventDBObjectMapper = statusHistoryEventDBObjectMapper;
     }
 
     @Override
@@ -54,7 +54,7 @@ public class FailedMessageConverter implements DBObjectWithIdConverter<FailedMes
                 .withSentDateTime(getSentDateTime(basicDBObject))
                 .withFailedDateTime(getFailedDateTime(basicDBObject))
                 .withContent(getContent(basicDBObject))
-                .withFailedMessageStatus(getFailedMessageStatus(basicDBObject))
+                .withStatusHistoryEvent(getStatusHistoryEvent(basicDBObject))
                 .withProperties(propertiesMongoMapper.convertToObject(basicDBObject.getString(PROPERTIES)))
                 .withLabels(getLabels(basicDBObject))
                 .build();
@@ -69,9 +69,9 @@ public class FailedMessageConverter implements DBObjectWithIdConverter<FailedMes
         return responses;
     }
 
-    public FailedMessageStatus getFailedMessageStatus(BasicDBObject basicDBObject) {
+    public StatusHistoryEvent getStatusHistoryEvent(BasicDBObject basicDBObject) {
         List statusHistory = (List)basicDBObject.get(STATUS_HISTORY);
-        return failedMessageStatusDBObjectMapper.convertToObject((BasicDBObject)statusHistory.get(0));
+        return statusHistoryEventDBObjectMapper.convertToObject((BasicDBObject)statusHistory.get(0));
     }
 
     public FailedMessageId getFailedMessageId(BasicDBObject basicDBObject) {
@@ -106,7 +106,7 @@ public class FailedMessageConverter implements DBObjectWithIdConverter<FailedMes
                 .append(FAILED_DATE_TIME, item.getFailedAt())
                 .append(CONTENT, item.getContent())
                 .append(PROPERTIES, propertiesMongoMapper.convertFromObject(item.getProperties()))
-                .append(STATUS_HISTORY, Collections.singletonList(failedMessageStatusDBObjectMapper.convertFromObject(item.getFailedMessageStatus())))
+                .append(STATUS_HISTORY, Collections.singletonList(statusHistoryEventDBObjectMapper.convertFromObject(item.getStatusHistoryEvent())))
                 .append(LABELS, DBObjectConverter.toBasicDBList(item.getLabels()))
                 ;
     }

--- a/core/dao-mongo/src/main/java/uk/gov/dwp/queue/triage/core/dao/mongo/FailedMessageStatusDBObjectConverter.java
+++ b/core/dao-mongo/src/main/java/uk/gov/dwp/queue/triage/core/dao/mongo/FailedMessageStatusDBObjectConverter.java
@@ -2,26 +2,26 @@ package uk.gov.dwp.queue.triage.core.dao.mongo;
 
 import com.mongodb.BasicDBObject;
 import com.mongodb.DBObject;
-import uk.gov.dwp.queue.triage.core.domain.FailedMessageStatus;
+import uk.gov.dwp.queue.triage.core.domain.StatusHistoryEvent;
 
 import java.time.Instant;
 
-public class FailedMessageStatusDBObjectConverter implements DBObjectConverter<FailedMessageStatus> {
+public class FailedMessageStatusDBObjectConverter implements DBObjectConverter<StatusHistoryEvent> {
 
     public static final String STATUS = "status";
     public static final String EFFECTIVE_DATE_TIME = "effectiveDateTime";
     public static final String LAST_MODIFIED_DATE_TIME = "_lastModifiedDateTime";
 
     @Override
-    public FailedMessageStatus convertToObject(DBObject dbObject) {
-        return new FailedMessageStatus(
-                FailedMessageStatus.Status.valueOf((String)dbObject.get(STATUS)),
+    public StatusHistoryEvent convertToObject(DBObject dbObject) {
+        return new StatusHistoryEvent(
+                StatusHistoryEvent.Status.valueOf((String)dbObject.get(STATUS)),
                 (Instant)dbObject.get(EFFECTIVE_DATE_TIME)
         );
     }
 
     @Override
-    public DBObject convertFromObject(FailedMessageStatus item) {
+    public DBObject convertFromObject(StatusHistoryEvent item) {
         return new BasicDBObject()
                 .append(STATUS, item.getStatus().name())
                 .append(EFFECTIVE_DATE_TIME, item.getEffectiveDateTime())

--- a/core/dao-mongo/src/main/java/uk/gov/dwp/queue/triage/core/dao/mongo/MongoStatusHistoryQueryBuilder.java
+++ b/core/dao-mongo/src/main/java/uk/gov/dwp/queue/triage/core/dao/mongo/MongoStatusHistoryQueryBuilder.java
@@ -1,7 +1,7 @@
 package uk.gov.dwp.queue.triage.core.dao.mongo;
 
 import com.mongodb.BasicDBObject;
-import uk.gov.dwp.queue.triage.core.domain.FailedMessageStatus.Status;
+import uk.gov.dwp.queue.triage.core.domain.StatusHistoryEvent.Status;
 
 import java.util.Set;
 

--- a/core/dao-mongo/src/main/java/uk/gov/dwp/queue/triage/core/dao/mongo/RemoveRecordsQueryFactory.java
+++ b/core/dao-mongo/src/main/java/uk/gov/dwp/queue/triage/core/dao/mongo/RemoveRecordsQueryFactory.java
@@ -8,7 +8,7 @@ import static java.time.temporal.ChronoUnit.DAYS;
 import static uk.gov.dwp.queue.triage.core.dao.mongo.FailedMessageConverter.STATUS_HISTORY;
 import static uk.gov.dwp.queue.triage.core.dao.mongo.FailedMessageStatusDBObjectConverter.STATUS;
 import static uk.gov.dwp.queue.triage.core.dao.mongo.FailedMessageStatusDBObjectConverter.EFFECTIVE_DATE_TIME;
-import static uk.gov.dwp.queue.triage.core.domain.FailedMessageStatus.Status.DELETED;
+import static uk.gov.dwp.queue.triage.core.domain.StatusHistoryEvent.Status.DELETED;
 
 public class RemoveRecordsQueryFactory {
 

--- a/core/dao-mongo/src/main/java/uk/gov/dwp/queue/triage/core/dao/mongo/configuration/MongoDaoConfig.java
+++ b/core/dao-mongo/src/main/java/uk/gov/dwp/queue/triage/core/dao/mongo/configuration/MongoDaoConfig.java
@@ -1,9 +1,7 @@
 package uk.gov.dwp.queue.triage.core.dao.mongo.configuration;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.mongodb.AuthenticationMechanism;
 import com.mongodb.MongoClient;
-import com.mongodb.MongoClientOptions;
 import com.mongodb.MongoCredential;
 import com.mongodb.ServerAddress;
 import org.bson.BSON;
@@ -22,15 +20,13 @@ import uk.gov.dwp.queue.triage.core.dao.mongo.FailedMessageConverter;
 import uk.gov.dwp.queue.triage.core.dao.mongo.FailedMessageMongoDao;
 import uk.gov.dwp.queue.triage.core.dao.mongo.FailedMessageStatusDBObjectConverter;
 import uk.gov.dwp.queue.triage.core.dao.mongo.RemoveRecordsQueryFactory;
-import uk.gov.dwp.queue.triage.core.dao.mongo.configuration.MongoDaoProperties.Collection;
 import uk.gov.dwp.queue.triage.core.domain.Destination;
-import uk.gov.dwp.queue.triage.core.domain.FailedMessageStatus;
+import uk.gov.dwp.queue.triage.core.domain.StatusHistoryEvent;
 import uk.gov.dwp.queue.triage.id.Id;
 import uk.gov.dwp.queue.triage.jackson.configuration.JacksonConfiguration;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -91,7 +87,7 @@ public class MongoDaoConfig {
     public FailedMessageDao failedMessageDao(MongoClient mongoClient,
                                              MongoDaoProperties mongoDaoProperties,
                                              FailedMessageConverter failedMessageConverter,
-                                             DBObjectConverter<FailedMessageStatus> failedMessageStatusDBObjectConverter) {
+                                             DBObjectConverter<StatusHistoryEvent> failedMessageStatusDBObjectConverter) {
         return new FailedMessageMongoDao(
                 mongoClient.getDB(mongoDaoProperties.getDbName()).getCollection(mongoDaoProperties.getFailedMessage().getName()),
                 failedMessageConverter,
@@ -100,7 +96,7 @@ public class MongoDaoConfig {
 
     @Bean
     public FailedMessageConverter failedMessageConverter(DBObjectConverter<Destination> destinationDBObjectConverter,
-                                                         DBObjectConverter<FailedMessageStatus> failedMessageStatusDBObjectConverter,
+                                                         DBObjectConverter<StatusHistoryEvent> failedMessageStatusDBObjectConverter,
                                                          ObjectConverter<Map<String, Object>, String> propertiesObjectConverter) {
         return new FailedMessageConverter(destinationDBObjectConverter, failedMessageStatusDBObjectConverter, propertiesObjectConverter);
     }

--- a/core/dao-mongo/src/test/java/uk/gov/dwp/queue/triage/core/dao/mongo/FailedMessageConverterTest.java
+++ b/core/dao-mongo/src/test/java/uk/gov/dwp/queue/triage/core/dao/mongo/FailedMessageConverterTest.java
@@ -12,8 +12,8 @@ import uk.gov.dwp.queue.triage.core.dao.ObjectConverter;
 import uk.gov.dwp.queue.triage.core.dao.mongo.configuration.MongoDaoConfig;
 import uk.gov.dwp.queue.triage.core.domain.Destination;
 import uk.gov.dwp.queue.triage.core.domain.FailedMessageBuilder;
-import uk.gov.dwp.queue.triage.core.domain.FailedMessageStatus;
-import uk.gov.dwp.queue.triage.core.domain.FailedMessageStatusMatcher;
+import uk.gov.dwp.queue.triage.core.domain.StatusHistoryEvent;
+import uk.gov.dwp.queue.triage.core.domain.StatusHistoryEventMatcher;
 import uk.gov.dwp.queue.triage.id.FailedMessageId;
 
 import java.time.Instant;
@@ -39,8 +39,8 @@ import static uk.gov.dwp.queue.triage.core.dao.mongo.FailedMessageConverter.LABE
 import static uk.gov.dwp.queue.triage.core.dao.mongo.FailedMessageConverter.PROPERTIES;
 import static uk.gov.dwp.queue.triage.core.domain.DestinationMatcher.aDestination;
 import static uk.gov.dwp.queue.triage.core.domain.FailedMessageMatcher.aFailedMessage;
-import static uk.gov.dwp.queue.triage.core.domain.FailedMessageStatus.Status.SENT;
-import static uk.gov.dwp.queue.triage.core.domain.FailedMessageStatus.failedMessageStatus;
+import static uk.gov.dwp.queue.triage.core.domain.StatusHistoryEvent.Status.SENT;
+import static uk.gov.dwp.queue.triage.core.domain.StatusHistoryEvent.statusHistoryEvent;
 import static uk.gov.dwp.queue.triage.id.FailedMessageId.newFailedMessageId;
 
 public class FailedMessageConverterTest {
@@ -55,7 +55,7 @@ public class FailedMessageConverterTest {
     }};
     private static final Destination SOME_DESTINATION = new Destination("broker", of("queue.name"));
     private static final BasicDBObject DESTINATION_DB_OBJECT = new BasicDBObject();
-    private static final FailedMessageStatus SOME_STATUS = failedMessageStatus(SENT);
+    private static final StatusHistoryEvent SOME_STATUS = statusHistoryEvent(SENT);
     private static final BasicDBObject STATUS_DB_OBJECT = new BasicDBObject();
     private static final Instant SENT_AT = Instant.now().minus(5, ChronoUnit.MINUTES);
     private static final Instant FAILED_AT = Instant.now();
@@ -63,7 +63,7 @@ public class FailedMessageConverterTest {
     @Mock
     private DBObjectConverter<Destination> destinationDBObjectConverter;
     @Mock
-    private DBObjectConverter<FailedMessageStatus> failedMessageStatusDBObjectConverter;
+    private DBObjectConverter<StatusHistoryEvent> failedMessageStatusDBObjectConverter;
     @Mock
     private ObjectConverter<Map<String, Object>, String> propertiesConverter;
 
@@ -79,7 +79,7 @@ public class FailedMessageConverterTest {
                 .withSentDateTime(SENT_AT)
                 .withFailedDateTime(FAILED_AT)
                 .withProperties(SOME_PROPERTIES)
-                .withFailedMessageStatus(SOME_STATUS)
+                .withStatusHistoryEvent(SOME_STATUS)
                 .withLabel("PR-1234")
         ;
         underTest = new MongoDaoConfig().failedMessageConverter(
@@ -121,7 +121,7 @@ public class FailedMessageConverterTest {
                 .withSentAt(SENT_AT)
                 .withFailedAt(FAILED_AT)
                 .withProperties(equalTo(SOME_PROPERTIES))
-                .withFailedMessageStatus(FailedMessageStatusMatcher.equalTo(SENT).withUpdatedDateTime(notNullValue(Instant.class)))
+                .withFailedMessageStatus(StatusHistoryEventMatcher.equalTo(SENT).withUpdatedDateTime(notNullValue(Instant.class)))
                 .withLabels(contains("PR-1234"))
         ));
     }
@@ -136,8 +136,8 @@ public class FailedMessageConverterTest {
         when(propertiesConverter.convertToObject(propertiesAsJson)).thenReturn(properties);
     }
 
-    private void primeFailedMessageStatusConverter(FailedMessageStatus failedMessageStatus, BasicDBObject statusDBObject) {
-        when(failedMessageStatusDBObjectConverter.convertFromObject(failedMessageStatus)).thenReturn(statusDBObject);
-        when(failedMessageStatusDBObjectConverter.convertToObject(statusDBObject)).thenReturn(failedMessageStatus);
+    private void primeFailedMessageStatusConverter(StatusHistoryEvent statusHistoryEvent, BasicDBObject statusDBObject) {
+        when(failedMessageStatusDBObjectConverter.convertFromObject(statusHistoryEvent)).thenReturn(statusDBObject);
+        when(failedMessageStatusDBObjectConverter.convertToObject(statusDBObject)).thenReturn(statusHistoryEvent);
     }
 }

--- a/core/dao-mongo/src/test/java/uk/gov/dwp/queue/triage/core/dao/mongo/FailedMessageMongoDaoTest.java
+++ b/core/dao-mongo/src/test/java/uk/gov/dwp/queue/triage/core/dao/mongo/FailedMessageMongoDaoTest.java
@@ -7,8 +7,8 @@ import uk.gov.dwp.queue.triage.core.dao.util.HashMapBuilder;
 import uk.gov.dwp.queue.triage.core.domain.Destination;
 import uk.gov.dwp.queue.triage.core.domain.FailedMessage;
 import uk.gov.dwp.queue.triage.core.domain.FailedMessageBuilder;
-import uk.gov.dwp.queue.triage.core.domain.FailedMessageStatus;
-import uk.gov.dwp.queue.triage.core.domain.FailedMessageStatusMatcher;
+import uk.gov.dwp.queue.triage.core.domain.StatusHistoryEvent;
+import uk.gov.dwp.queue.triage.core.domain.StatusHistoryEventMatcher;
 import uk.gov.dwp.queue.triage.id.FailedMessageId;
 
 import java.time.Instant;
@@ -30,11 +30,11 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static uk.gov.dwp.queue.triage.core.dao.util.HashMapBuilder.newHashMap;
 import static uk.gov.dwp.queue.triage.core.domain.FailedMessageMatcher.aFailedMessage;
-import static uk.gov.dwp.queue.triage.core.domain.FailedMessageStatus.Status.DELETED;
-import static uk.gov.dwp.queue.triage.core.domain.FailedMessageStatus.Status.FAILED;
-import static uk.gov.dwp.queue.triage.core.domain.FailedMessageStatus.Status.RESEND;
-import static uk.gov.dwp.queue.triage.core.domain.FailedMessageStatus.Status.SENT;
-import static uk.gov.dwp.queue.triage.core.domain.FailedMessageStatus.failedMessageStatus;
+import static uk.gov.dwp.queue.triage.core.domain.StatusHistoryEvent.Status.DELETED;
+import static uk.gov.dwp.queue.triage.core.domain.StatusHistoryEvent.Status.FAILED;
+import static uk.gov.dwp.queue.triage.core.domain.StatusHistoryEvent.Status.RESEND;
+import static uk.gov.dwp.queue.triage.core.domain.StatusHistoryEvent.Status.SENT;
+import static uk.gov.dwp.queue.triage.core.domain.StatusHistoryEvent.statusHistoryEvent;
 import static uk.gov.dwp.queue.triage.id.FailedMessageId.newFailedMessageId;
 
 public class FailedMessageMongoDaoTest extends AbstractMongoDaoTest {
@@ -68,7 +68,7 @@ public class FailedMessageMongoDaoTest extends AbstractMongoDaoTest {
                 .withFailedMessageId(equalTo(failedMessageId))
                 .withContent(equalTo("Hello"))
                 .withProperties(equalTo(emptyMap()))
-                .withFailedMessageStatus(FailedMessageStatusMatcher.equalTo(FAILED))
+                .withFailedMessageStatus(StatusHistoryEventMatcher.equalTo(FAILED))
                 .withLabels(emptyIterable())
         ));
     }
@@ -96,7 +96,7 @@ public class FailedMessageMongoDaoTest extends AbstractMongoDaoTest {
                 .withFailedMessageId(equalTo(failedMessageId))
                 .withContent(equalTo("Hello"))
                 .withProperties(equalTo(properties))
-                .withFailedMessageStatus(FailedMessageStatusMatcher.equalTo(FAILED))
+                .withFailedMessageStatus(StatusHistoryEventMatcher.equalTo(FAILED))
                 .withLabels(containsInAnyOrder("foo", "bar"))
         ));
     }
@@ -128,11 +128,11 @@ public class FailedMessageMongoDaoTest extends AbstractMongoDaoTest {
     @Test
     public void updateStatus() {
         underTest.insert(failedMessageBuilder.build());
-        underTest.updateStatus(failedMessageId, failedMessageStatus(RESEND));
+        underTest.updateStatus(failedMessageId, statusHistoryEvent(RESEND));
 
         assertThat(underTest.getStatusHistory(failedMessageId), contains(
-                FailedMessageStatusMatcher.equalTo(RESEND),
-                FailedMessageStatusMatcher.equalTo(FAILED)
+                StatusHistoryEventMatcher.equalTo(RESEND),
+                StatusHistoryEventMatcher.equalTo(FAILED)
         ));
     }
 
@@ -224,10 +224,10 @@ public class FailedMessageMongoDaoTest extends AbstractMongoDaoTest {
         assertThat(collection.count(), is(0L));
     }
 
-    public FailedMessage newFailedMessageWithStatus(FailedMessageStatus.Status status, Instant instant) {
+    public FailedMessage newFailedMessageWithStatus(StatusHistoryEvent.Status status, Instant instant) {
         return failedMessageBuilder
                 .withNewFailedMessageId()
-                .withFailedMessageStatus(new FailedMessageStatus(status, instant))
+                .withStatusHistoryEvent(new StatusHistoryEvent(status, instant))
                 .build();
     }
 

--- a/core/dao-mongo/src/test/java/uk/gov/dwp/queue/triage/core/dao/mongo/MongoStatusHistoryQueryBuilderTest.java
+++ b/core/dao-mongo/src/test/java/uk/gov/dwp/queue/triage/core/dao/mongo/MongoStatusHistoryQueryBuilderTest.java
@@ -13,9 +13,9 @@ import static org.hamcrest.Matchers.is;
 import static uk.gov.dwp.queue.triage.core.dao.mongo.DBObjectMatcher.hasField;
 import static uk.gov.dwp.queue.triage.core.dao.mongo.FailedMessageConverter.STATUS_HISTORY;
 import static uk.gov.dwp.queue.triage.core.dao.mongo.FailedMessageStatusDBObjectConverter.STATUS;
-import static uk.gov.dwp.queue.triage.core.domain.FailedMessageStatus.Status.CLASSIFIED;
-import static uk.gov.dwp.queue.triage.core.domain.FailedMessageStatus.Status.DELETED;
-import static uk.gov.dwp.queue.triage.core.domain.FailedMessageStatus.Status.FAILED;
+import static uk.gov.dwp.queue.triage.core.domain.StatusHistoryEvent.Status.CLASSIFIED;
+import static uk.gov.dwp.queue.triage.core.domain.StatusHistoryEvent.Status.DELETED;
+import static uk.gov.dwp.queue.triage.core.domain.StatusHistoryEvent.Status.FAILED;
 
 public class MongoStatusHistoryQueryBuilderTest {
 

--- a/core/dao-mongo/src/test/java/uk/gov/dwp/queue/triage/core/dao/mongo/StatusHistoryEventDBObjectConverterTest.java
+++ b/core/dao-mongo/src/test/java/uk/gov/dwp/queue/triage/core/dao/mongo/StatusHistoryEventDBObjectConverterTest.java
@@ -2,16 +2,16 @@ package uk.gov.dwp.queue.triage.core.dao.mongo;
 
 import com.mongodb.DBObject;
 import org.junit.Test;
-import uk.gov.dwp.queue.triage.core.domain.FailedMessageStatus;
+import uk.gov.dwp.queue.triage.core.domain.StatusHistoryEvent;
 
 import java.time.Instant;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
-import static uk.gov.dwp.queue.triage.core.domain.FailedMessageStatus.Status.FAILED;
-import static uk.gov.dwp.queue.triage.core.domain.FailedMessageStatusMatcher.equalTo;
+import static uk.gov.dwp.queue.triage.core.domain.StatusHistoryEvent.Status.FAILED;
+import static uk.gov.dwp.queue.triage.core.domain.StatusHistoryEventMatcher.equalTo;
 
-public class FailedMessageStatusDBObjectConverterTest {
+public class StatusHistoryEventDBObjectConverterTest {
 
     private static final Instant NOW = Instant.now();
 
@@ -19,7 +19,7 @@ public class FailedMessageStatusDBObjectConverterTest {
 
     @Test
     public void testConvertQueueToDBObjectAndBack() throws Exception {
-        DBObject basicDBObject = underTest.convertFromObject(new FailedMessageStatus(FAILED, NOW));
+        DBObject basicDBObject = underTest.convertFromObject(new StatusHistoryEvent(FAILED, NOW));
 
         assertThat(underTest.convertToObject(basicDBObject), is(equalTo(FAILED).withUpdatedDateTime(NOW)));
     }

--- a/core/dao/src/main/java/uk/gov/dwp/queue/triage/core/dao/FailedMessageDao.java
+++ b/core/dao/src/main/java/uk/gov/dwp/queue/triage/core/dao/FailedMessageDao.java
@@ -1,7 +1,7 @@
 package uk.gov.dwp.queue.triage.core.dao;
 
 import uk.gov.dwp.queue.triage.core.domain.FailedMessage;
-import uk.gov.dwp.queue.triage.core.domain.FailedMessageStatus;
+import uk.gov.dwp.queue.triage.core.domain.StatusHistoryEvent;
 import uk.gov.dwp.queue.triage.id.FailedMessageId;
 
 import java.util.List;
@@ -15,9 +15,9 @@ public interface FailedMessageDao {
 
     long findNumberOfMessagesForBroker(String broker);
 
-    void updateStatus(FailedMessageId failedMessageId, FailedMessageStatus failedMessageStatus);
+    void updateStatus(FailedMessageId failedMessageId, StatusHistoryEvent statusHistoryEvent);
 
-    List<FailedMessageStatus> getStatusHistory(FailedMessageId failedMessageId);
+    List<StatusHistoryEvent> getStatusHistory(FailedMessageId failedMessageId);
 
     int removeFailedMessages();
 

--- a/core/domain-test-support/src/main/java/uk/gov/dwp/queue/triage/core/domain/FailedMessageMatcher.java
+++ b/core/domain-test-support/src/main/java/uk/gov/dwp/queue/triage/core/domain/FailedMessageMatcher.java
@@ -8,7 +8,6 @@ import uk.gov.dwp.queue.triage.id.FailedMessageId;
 
 import java.time.Instant;
 import java.util.Map;
-import java.util.Set;
 
 import static org.hamcrest.Matchers.equalTo;
 
@@ -20,7 +19,7 @@ public class FailedMessageMatcher extends TypeSafeMatcher<FailedMessage> {
     private Matcher<Instant> sentAtMatcher = new IsAnything<>();
     private Matcher<Instant> failedAtMatcher = new IsAnything<>();
     private Matcher<Map<? extends String, ? extends Object>> propertiesMatcher = new IsAnything<>();
-    private Matcher<FailedMessageStatus> failedMessageStatusMatcher = new IsAnything<>();
+    private Matcher<StatusHistoryEvent> failedMessageStatusMatcher = new IsAnything<>();
     private Matcher<Iterable<? extends String>> labelsMatcher = new IsAnything<>();
 
     private FailedMessageMatcher() { }
@@ -69,7 +68,7 @@ public class FailedMessageMatcher extends TypeSafeMatcher<FailedMessage> {
         return this;
     }
 
-    public FailedMessageMatcher withFailedMessageStatus(Matcher<FailedMessageStatus> failedMessageStatusMatcher) {
+    public FailedMessageMatcher withFailedMessageStatus(Matcher<StatusHistoryEvent> failedMessageStatusMatcher) {
         this.failedMessageStatusMatcher = failedMessageStatusMatcher;
         return this;
     }
@@ -87,7 +86,7 @@ public class FailedMessageMatcher extends TypeSafeMatcher<FailedMessage> {
                 && sentAtMatcher.matches(item.getSentAt())
                 && failedAtMatcher.matches(item.getFailedAt())
                 && propertiesMatcher.matches(item.getProperties())
-                && failedMessageStatusMatcher.matches(item.getFailedMessageStatus())
+                && failedMessageStatusMatcher.matches(item.getStatusHistoryEvent())
                 && labelsMatcher.matches(item.getLabels())
                 ;
     }

--- a/core/domain-test-support/src/main/java/uk/gov/dwp/queue/triage/core/domain/StatusHistoryEventMatcher.java
+++ b/core/domain-test-support/src/main/java/uk/gov/dwp/queue/triage/core/domain/StatusHistoryEventMatcher.java
@@ -4,41 +4,41 @@ import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 import org.hamcrest.TypeSafeMatcher;
-import uk.gov.dwp.queue.triage.core.domain.FailedMessageStatus.Status;
+import uk.gov.dwp.queue.triage.core.domain.StatusHistoryEvent.Status;
 
 import java.time.Instant;
 
 import static org.hamcrest.Matchers.notNullValue;
 
-public class FailedMessageStatusMatcher extends TypeSafeMatcher<FailedMessageStatus> {
+public class StatusHistoryEventMatcher extends TypeSafeMatcher<StatusHistoryEvent> {
 
     private Status status;
     private Matcher<Instant> updatedDateTimeMatcher = notNullValue(Instant.class);
 
-    public static FailedMessageStatusMatcher equalTo(Status status) {
-        return new FailedMessageStatusMatcher()
+    public static StatusHistoryEventMatcher equalTo(Status status) {
+        return new StatusHistoryEventMatcher()
                 .withStatus(status);
     }
 
-    private FailedMessageStatusMatcher withStatus(Status status) {
+    private StatusHistoryEventMatcher withStatus(Status status) {
         this.status = status;
         return this;
     }
 
-    public FailedMessageStatusMatcher withUpdatedDateTime(Instant updatedDateTime) {
+    public StatusHistoryEventMatcher withUpdatedDateTime(Instant updatedDateTime) {
         this.updatedDateTimeMatcher = Matchers.equalTo(updatedDateTime);
         return this;
     }
 
-    public FailedMessageStatusMatcher withUpdatedDateTime(Matcher<Instant> updatedDateTimeMatcher) {
+    public StatusHistoryEventMatcher withUpdatedDateTime(Matcher<Instant> updatedDateTimeMatcher) {
         this.updatedDateTimeMatcher = updatedDateTimeMatcher;
         return this;
     }
 
     @Override
-    protected boolean matchesSafely(FailedMessageStatus failedMessageStatus) {
-        return status == failedMessageStatus.getStatus() &&
-                updatedDateTimeMatcher.matches(failedMessageStatus.getEffectiveDateTime());
+    protected boolean matchesSafely(StatusHistoryEvent statusHistoryEvent) {
+        return status == statusHistoryEvent.getStatus() &&
+                updatedDateTimeMatcher.matches(statusHistoryEvent.getEffectiveDateTime());
     }
 
     @Override

--- a/core/domain/src/main/java/uk/gov/dwp/queue/triage/core/domain/FailedMessage.java
+++ b/core/domain/src/main/java/uk/gov/dwp/queue/triage/core/domain/FailedMessage.java
@@ -17,7 +17,7 @@ public class FailedMessage {
     private final Instant failedAt;
     private final String content;
     private final Map<String, Object> properties;
-    private final FailedMessageStatus failedMessageStatus;
+    private final StatusHistoryEvent statusHistoryEvent;
     private final Set<String> labels;
 
     FailedMessage(FailedMessageId failedMessageId,
@@ -26,7 +26,7 @@ public class FailedMessage {
                   Instant failedAt,
                   String content,
                   Map<String, Object> properties,
-                  FailedMessageStatus failedMessageStatus,
+                  StatusHistoryEvent statusHistoryEvent,
                   Set<String> labels) {
         this.failedMessageId = failedMessageId;
         this.destination = destination;
@@ -34,7 +34,7 @@ public class FailedMessage {
         this.failedAt = failedAt;
         this.content = content;
         this.properties = properties;
-        this.failedMessageStatus = failedMessageStatus;
+        this.statusHistoryEvent = statusHistoryEvent;
         this.labels = labels;
     }
 
@@ -75,7 +75,7 @@ public class FailedMessage {
         return reflectionToString(this);
     }
 
-    public FailedMessageStatus getFailedMessageStatus() {
-        return failedMessageStatus;
+    public StatusHistoryEvent getStatusHistoryEvent() {
+        return statusHistoryEvent;
     }
 }

--- a/core/domain/src/main/java/uk/gov/dwp/queue/triage/core/domain/FailedMessageBuilder.java
+++ b/core/domain/src/main/java/uk/gov/dwp/queue/triage/core/domain/FailedMessageBuilder.java
@@ -1,6 +1,6 @@
 package uk.gov.dwp.queue.triage.core.domain;
 
-import uk.gov.dwp.queue.triage.core.domain.FailedMessageStatus.Status;
+import uk.gov.dwp.queue.triage.core.domain.StatusHistoryEvent.Status;
 import uk.gov.dwp.queue.triage.id.FailedMessageId;
 
 import java.time.Instant;
@@ -17,7 +17,7 @@ public class FailedMessageBuilder {
     private Instant failedDateTime;
     private String content;
     private Map<String, Object> properties = new HashMap<>();
-    private FailedMessageStatus failedMessageStatus;
+    private StatusHistoryEvent statusHistoryEvent;
     private Set<String> labels = new HashSet<>();
 
     private FailedMessageBuilder() {
@@ -25,7 +25,7 @@ public class FailedMessageBuilder {
 
     public static FailedMessageBuilder newFailedMessage() {
         return new FailedMessageBuilder()
-                .withFailedMessageStatus(Status.FAILED);
+                .withStatusHistoryEvent(Status.FAILED);
     }
 
     public static FailedMessageBuilder clone(FailedMessage failedMessage) {
@@ -36,12 +36,12 @@ public class FailedMessageBuilder {
                 .withFailedDateTime(failedMessage.getFailedAt())
                 .withContent(failedMessage.getContent())
                 .withProperties(failedMessage.getProperties())
-                .withFailedMessageStatus(failedMessage.getFailedMessageStatus())
+                .withStatusHistoryEvent(failedMessage.getStatusHistoryEvent())
                 .withLabels(failedMessage.getLabels());
     }
 
     public FailedMessage build() {
-        return new FailedMessage(failedMessageId, destination, sentDateTime, failedDateTime, content, properties, failedMessageStatus, labels);
+        return new FailedMessage(failedMessageId, destination, sentDateTime, failedDateTime, content, properties, statusHistoryEvent, labels);
     }
 
     public FailedMessageBuilder withNewFailedMessageId() {
@@ -84,13 +84,13 @@ public class FailedMessageBuilder {
         return this;
     }
 
-    public FailedMessageBuilder withFailedMessageStatus(Status status) {
-        this.failedMessageStatus = FailedMessageStatus.failedMessageStatus(status);
+    public FailedMessageBuilder withStatusHistoryEvent(Status status) {
+        this.statusHistoryEvent = StatusHistoryEvent.statusHistoryEvent(status);
         return this;
     }
 
-    public FailedMessageBuilder withFailedMessageStatus(FailedMessageStatus failedMessageStatus) {
-        this.failedMessageStatus = failedMessageStatus;
+    public FailedMessageBuilder withStatusHistoryEvent(StatusHistoryEvent statusHistoryEvent) {
+        this.statusHistoryEvent = statusHistoryEvent;
         return this;
     }
 

--- a/core/domain/src/main/java/uk/gov/dwp/queue/triage/core/domain/FailedMessageStatusAdapter.java
+++ b/core/domain/src/main/java/uk/gov/dwp/queue/triage/core/domain/FailedMessageStatusAdapter.java
@@ -4,7 +4,7 @@ import com.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.dwp.queue.triage.core.client.FailedMessageStatus;
-import uk.gov.dwp.queue.triage.core.domain.FailedMessageStatus.Status;
+import uk.gov.dwp.queue.triage.core.domain.StatusHistoryEvent.Status;
 
 import java.util.HashMap;
 import java.util.HashSet;

--- a/core/domain/src/main/java/uk/gov/dwp/queue/triage/core/domain/StatusHistoryEvent.java
+++ b/core/domain/src/main/java/uk/gov/dwp/queue/triage/core/domain/StatusHistoryEvent.java
@@ -2,16 +2,16 @@ package uk.gov.dwp.queue.triage.core.domain;
 
 import java.time.Instant;
 
-public class FailedMessageStatus {
+public class StatusHistoryEvent {
 
     private final Status status;
     private final Instant updatedDateTime;
 
-    public static FailedMessageStatus failedMessageStatus(Status status) {
-        return new FailedMessageStatus(status, Instant.now());
+    public static StatusHistoryEvent statusHistoryEvent(Status status) {
+        return new StatusHistoryEvent(status, Instant.now());
     }
 
-    public FailedMessageStatus(Status status, Instant updatedDateTime) {
+    public StatusHistoryEvent(Status status, Instant updatedDateTime) {
         this.status = status;
         this.updatedDateTime = updatedDateTime;
     }

--- a/core/domain/src/test/java/uk/gov/dwp/queue/triage/core/domain/FailedMessageBuilderTest.java
+++ b/core/domain/src/test/java/uk/gov/dwp/queue/triage/core/domain/FailedMessageBuilderTest.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static uk.gov.dwp.queue.triage.core.domain.FailedMessageStatus.Status.FAILED;
+import static uk.gov.dwp.queue.triage.core.domain.StatusHistoryEvent.Status.FAILED;
 
 public class FailedMessageBuilderTest {
 
@@ -28,7 +28,7 @@ public class FailedMessageBuilderTest {
             .withDestination(new Destination(BROKER_NAME, Optional.of(DESTINATION_NAME)))
             .withFailedDateTime(FAILED_DATE_TIME)
             .withFailedMessageId(FAILED_MESSAGE_ID)
-            .withFailedMessageStatus(FAILED)
+            .withStatusHistoryEvent(FAILED)
             .withSentDateTime(SEND_DATE_TIME);
 
     @Test
@@ -57,7 +57,7 @@ public class FailedMessageBuilderTest {
                 .withDestination(DestinationMatcher.aDestination().withBrokerName(BROKER_NAME).withName(DESTINATION_NAME))
                 .withFailedAt(FAILED_DATE_TIME)
                 .withFailedMessageId(equalTo(FAILED_MESSAGE_ID))
-                .withFailedMessageStatus(FailedMessageStatusMatcher.equalTo(FAILED))
+                .withFailedMessageStatus(StatusHistoryEventMatcher.equalTo(FAILED))
                 .withSentAt(SEND_DATE_TIME);
     }
 }

--- a/core/domain/src/test/java/uk/gov/dwp/queue/triage/core/domain/StatusHistoryEventAdapterTest.java
+++ b/core/domain/src/test/java/uk/gov/dwp/queue/triage/core/domain/StatusHistoryEventAdapterTest.java
@@ -2,7 +2,7 @@ package uk.gov.dwp.queue.triage.core.domain;
 
 import org.junit.Test;
 import uk.gov.dwp.queue.triage.core.client.FailedMessageStatus;
-import uk.gov.dwp.queue.triage.core.domain.FailedMessageStatus.Status;
+import uk.gov.dwp.queue.triage.core.domain.StatusHistoryEvent.Status;
 
 import java.util.Arrays;
 import java.util.List;
@@ -17,10 +17,10 @@ import static org.junit.Assert.fail;
 import static uk.gov.dwp.queue.triage.core.domain.FailedMessageStatusAdapter.fromFailedMessageStatus;
 import static uk.gov.dwp.queue.triage.core.domain.FailedMessageStatusAdapter.toFailedMessageStatus;
 
-public class FailedMessageStatusAdapterTest {
+public class StatusHistoryEventAdapterTest {
 
     @Test
-    public void ensureStatusCanBeAdaptedFromInternalToExternal() throws Exception {
+    public void ensureStatusCanBeAdaptedFromInternalToExternal() {
         List<Status> internalStatuses = Arrays.asList(Status.DELETED);
 
         for (Status status : Status.values()) {
@@ -42,7 +42,7 @@ public class FailedMessageStatusAdapterTest {
             try {
                 assertThat(fromFailedMessageStatus(failedMessageStatus), is(notNullValue()));
             } catch (IllegalArgumentException e) {
-                fail(format("FailedMessageStatus '%s' has no mapping to %s", failedMessageStatus, Status.class));
+                fail(format("StatusHistoryEvent '%s' has no mapping to %s", failedMessageStatus, Status.class));
             }
         }
     }

--- a/core/message-classification/src/main/java/uk/gov/dwp/queue/triage/core/classification/server/MessageClassificationService.java
+++ b/core/message-classification/src/main/java/uk/gov/dwp/queue/triage/core/classification/server/MessageClassificationService.java
@@ -10,7 +10,7 @@ import uk.gov.dwp.queue.triage.core.search.FailedMessageSearchService;
 import java.util.Collection;
 import java.util.List;
 
-import static uk.gov.dwp.queue.triage.core.domain.FailedMessageStatus.Status.FAILED;
+import static uk.gov.dwp.queue.triage.core.domain.StatusHistoryEvent.Status.FAILED;
 
 public class MessageClassificationService {
 

--- a/core/message-classification/src/test/java/uk/gov/dwp/queue/triage/core/classification/server/MessageClassificationServiceTest.java
+++ b/core/message-classification/src/test/java/uk/gov/dwp/queue/triage/core/classification/server/MessageClassificationServiceTest.java
@@ -15,7 +15,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
-import static uk.gov.dwp.queue.triage.core.domain.FailedMessageStatus.Status.FAILED;
+import static uk.gov.dwp.queue.triage.core.domain.StatusHistoryEvent.Status.FAILED;
 
 public class MessageClassificationServiceTest {
 

--- a/core/resend/src/main/java/uk/gov/dwp/queue/triage/core/resend/FailedMessageSender.java
+++ b/core/resend/src/main/java/uk/gov/dwp/queue/triage/core/resend/FailedMessageSender.java
@@ -6,7 +6,7 @@ import uk.gov.dwp.queue.triage.core.domain.FailedMessage;
 import uk.gov.dwp.queue.triage.core.jms.MessageSender;
 import uk.gov.dwp.queue.triage.core.service.FailedMessageService;
 
-import static uk.gov.dwp.queue.triage.core.domain.FailedMessageStatus.Status.SENT;
+import static uk.gov.dwp.queue.triage.core.domain.StatusHistoryEvent.Status.SENT;
 
 public class FailedMessageSender implements MessageSender {
 

--- a/core/resend/src/main/java/uk/gov/dwp/queue/triage/core/resend/HistoricStatusPredicate.java
+++ b/core/resend/src/main/java/uk/gov/dwp/queue/triage/core/resend/HistoricStatusPredicate.java
@@ -8,6 +8,6 @@ import java.util.function.Predicate;
 public class HistoricStatusPredicate implements Predicate<FailedMessage> {
     @Override
     public boolean test(FailedMessage failedMessage) {
-        return failedMessage.getFailedMessageStatus().getEffectiveDateTime().isBefore(Instant.now());
+        return failedMessage.getStatusHistoryEvent().getEffectiveDateTime().isBefore(Instant.now());
     }
 }

--- a/core/resend/src/test/java/uk/gov/dwp/queue/triage/core/resend/FailedMessageSenderTest.java
+++ b/core/resend/src/test/java/uk/gov/dwp/queue/triage/core/resend/FailedMessageSenderTest.java
@@ -9,7 +9,7 @@ import uk.gov.dwp.queue.triage.id.FailedMessageId;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.dwp.queue.triage.core.domain.FailedMessageStatus.Status.SENT;
+import static uk.gov.dwp.queue.triage.core.domain.StatusHistoryEvent.Status.SENT;
 
 public class FailedMessageSenderTest {
 

--- a/core/resend/src/test/java/uk/gov/dwp/queue/triage/core/resend/HistoricStatusPredicateTest.java
+++ b/core/resend/src/test/java/uk/gov/dwp/queue/triage/core/resend/HistoricStatusPredicateTest.java
@@ -2,7 +2,7 @@ package uk.gov.dwp.queue.triage.core.resend;
 
 import org.junit.Test;
 import uk.gov.dwp.queue.triage.core.domain.FailedMessage;
-import uk.gov.dwp.queue.triage.core.domain.FailedMessageStatus;
+import uk.gov.dwp.queue.triage.core.domain.StatusHistoryEvent;
 
 import java.time.Instant;
 
@@ -16,22 +16,22 @@ import static org.mockito.Mockito.when;
 public class HistoricStatusPredicateTest {
 
     private final FailedMessage failedMessage = mock(FailedMessage.class);
-    private final FailedMessageStatus failedMessageStatus = mock(FailedMessageStatus.class);
+    private final StatusHistoryEvent statusHistoryEvent = mock(StatusHistoryEvent.class);
 
     private final HistoricStatusPredicate underTest = new HistoricStatusPredicate();
 
     @Test
     public void effectiveDateTimeInPastReturnsTrue() throws Exception {
-        when(failedMessage.getFailedMessageStatus()).thenReturn(failedMessageStatus);
-        when(failedMessageStatus.getEffectiveDateTime()).thenReturn(Instant.now().minus(1, MILLIS));
+        when(failedMessage.getStatusHistoryEvent()).thenReturn(statusHistoryEvent);
+        when(statusHistoryEvent.getEffectiveDateTime()).thenReturn(Instant.now().minus(1, MILLIS));
 
         assertThat(underTest.test(failedMessage), is(true));
     }
 
     @Test
     public void effectiveDateTimeInFutureReturnsFalse() throws Exception {
-        when(failedMessage.getFailedMessageStatus()).thenReturn(failedMessageStatus);
-        when(failedMessageStatus.getEffectiveDateTime()).thenReturn(Instant.now().plus(1, SECONDS));
+        when(failedMessage.getStatusHistoryEvent()).thenReturn(statusHistoryEvent);
+        when(statusHistoryEvent.getEffectiveDateTime()).thenReturn(Instant.now().plus(1, SECONDS));
 
         assertThat(underTest.test(failedMessage), is(false));
     }

--- a/core/search/src/main/java/uk/gov/dwp/queue/triage/core/search/FailedMessageSearchService.java
+++ b/core/search/src/main/java/uk/gov/dwp/queue/triage/core/search/FailedMessageSearchService.java
@@ -2,7 +2,7 @@ package uk.gov.dwp.queue.triage.core.search;
 
 import uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageRequest;
 import uk.gov.dwp.queue.triage.core.domain.FailedMessage;
-import uk.gov.dwp.queue.triage.core.domain.FailedMessageStatus.Status;
+import uk.gov.dwp.queue.triage.core.domain.StatusHistoryEvent.Status;
 
 import java.util.Collection;
 

--- a/core/search/src/main/java/uk/gov/dwp/queue/triage/core/search/mongo/MongoFailedMessageSearchService.java
+++ b/core/search/src/main/java/uk/gov/dwp/queue/triage/core/search/mongo/MongoFailedMessageSearchService.java
@@ -6,7 +6,7 @@ import uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageRequest;
 import uk.gov.dwp.queue.triage.core.dao.mongo.FailedMessageConverter;
 import uk.gov.dwp.queue.triage.core.dao.mongo.MongoStatusHistoryQueryBuilder;
 import uk.gov.dwp.queue.triage.core.domain.FailedMessage;
-import uk.gov.dwp.queue.triage.core.domain.FailedMessageStatus;
+import uk.gov.dwp.queue.triage.core.domain.StatusHistoryEvent;
 import uk.gov.dwp.queue.triage.core.search.FailedMessageSearchService;
 
 import java.util.Collection;
@@ -42,7 +42,7 @@ public class MongoFailedMessageSearchService implements FailedMessageSearchServi
     }
 
     @Override
-    public Collection<FailedMessage> findByStatus(FailedMessageStatus.Status status) {
+    public Collection<FailedMessage> findByStatus(StatusHistoryEvent.Status status) {
         List<FailedMessage> responses = failedMessageConverter
                 .convertToList(dbCollection.find(mongoStatusHistoryQueryBuilder.currentStatusEqualTo(status)));
         LOGGER.debug("Found {} results", responses.size());

--- a/core/search/src/main/java/uk/gov/dwp/queue/triage/core/search/mongo/MongoSearchRequestAdapter.java
+++ b/core/search/src/main/java/uk/gov/dwp/queue/triage/core/search/mongo/MongoSearchRequestAdapter.java
@@ -15,7 +15,7 @@ import static uk.gov.dwp.queue.triage.core.dao.mongo.DestinationDBObjectConverte
 import static uk.gov.dwp.queue.triage.core.dao.mongo.DestinationDBObjectConverter.NAME;
 import static uk.gov.dwp.queue.triage.core.dao.mongo.FailedMessageConverter.CONTENT;
 import static uk.gov.dwp.queue.triage.core.dao.mongo.FailedMessageConverter.DESTINATION;
-import static uk.gov.dwp.queue.triage.core.domain.FailedMessageStatus.Status.DELETED;
+import static uk.gov.dwp.queue.triage.core.domain.StatusHistoryEvent.Status.DELETED;
 import static uk.gov.dwp.queue.triage.core.domain.FailedMessageStatusAdapter.fromFailedMessageStatus;
 
 public class MongoSearchRequestAdapter {

--- a/core/search/src/test/java/uk/gov/dwp/queue/triage/core/search/mongo/MongoFailedMessageSearchServiceTest.java
+++ b/core/search/src/test/java/uk/gov/dwp/queue/triage/core/search/mongo/MongoFailedMessageSearchServiceTest.java
@@ -19,7 +19,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.dwp.queue.triage.core.domain.FailedMessageStatus.Status.FAILED;
+import static uk.gov.dwp.queue.triage.core.domain.StatusHistoryEvent.Status.FAILED;
 
 public class MongoFailedMessageSearchServiceTest {
 

--- a/core/server/src/main/java/uk/gov/dwp/queue/triage/core/resource/resend/ResendFailedMessageResource.java
+++ b/core/server/src/main/java/uk/gov/dwp/queue/triage/core/resource/resend/ResendFailedMessageResource.java
@@ -1,7 +1,7 @@
 package uk.gov.dwp.queue.triage.core.resource.resend;
 
 import uk.gov.dwp.queue.triage.core.client.resend.ResendFailedMessageClient;
-import uk.gov.dwp.queue.triage.core.domain.FailedMessageStatus;
+import uk.gov.dwp.queue.triage.core.domain.StatusHistoryEvent;
 import uk.gov.dwp.queue.triage.core.service.FailedMessageService;
 import uk.gov.dwp.queue.triage.id.FailedMessageId;
 
@@ -9,7 +9,7 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 
-import static uk.gov.dwp.queue.triage.core.domain.FailedMessageStatus.Status.RESEND;
+import static uk.gov.dwp.queue.triage.core.domain.StatusHistoryEvent.Status.RESEND;
 
 public class ResendFailedMessageResource implements ResendFailedMessageClient {
 
@@ -31,7 +31,7 @@ public class ResendFailedMessageResource implements ResendFailedMessageClient {
     public void resendFailedMessageWithDelay(FailedMessageId failedMessageId, Duration duration) {
         failedMessageService.updateStatus(
                 failedMessageId,
-                new FailedMessageStatus(RESEND, Instant.now(clock).plus(duration))
+                new StatusHistoryEvent(RESEND, Instant.now(clock).plus(duration))
         );
     }
 }

--- a/core/server/src/main/java/uk/gov/dwp/queue/triage/core/resource/search/FailedMessageResponseFactory.java
+++ b/core/server/src/main/java/uk/gov/dwp/queue/triage/core/resource/search/FailedMessageResponseFactory.java
@@ -20,7 +20,7 @@ public class FailedMessageResponseFactory {
                 failedMessage.getSentAt(),
                 failedMessage.getFailedAt(),
                 failedMessage.getContent(),
-                failedMessageStatusAdapter.toFailedMessageStatus(failedMessage.getFailedMessageStatus().getStatus()),
+                failedMessageStatusAdapter.toFailedMessageStatus(failedMessage.getStatusHistoryEvent().getStatus()),
                 failedMessage.getProperties(),
                 failedMessage.getLabels());
     }

--- a/core/server/src/test/java/uk/gov/dwp/queue/triage/core/resource/resend/ResendFailedMessageResourceTest.java
+++ b/core/server/src/test/java/uk/gov/dwp/queue/triage/core/resource/resend/ResendFailedMessageResourceTest.java
@@ -3,7 +3,7 @@ package uk.gov.dwp.queue.triage.core.resource.resend;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.mockito.internal.hamcrest.HamcrestArgumentMatcher;
-import uk.gov.dwp.queue.triage.core.domain.FailedMessageStatusMatcher;
+import uk.gov.dwp.queue.triage.core.domain.StatusHistoryEventMatcher;
 import uk.gov.dwp.queue.triage.core.service.FailedMessageService;
 import uk.gov.dwp.queue.triage.id.FailedMessageId;
 
@@ -17,7 +17,7 @@ import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static uk.gov.dwp.queue.triage.core.domain.FailedMessageStatus.Status.RESEND;
+import static uk.gov.dwp.queue.triage.core.domain.StatusHistoryEvent.Status.RESEND;
 
 public class ResendFailedMessageResourceTest {
 
@@ -41,7 +41,7 @@ public class ResendFailedMessageResourceTest {
 
         verify(failedMessageService).updateStatus(
                 eq(FAILED_MESSAGE_ID),
-                argThat(new HamcrestArgumentMatcher<>(FailedMessageStatusMatcher.equalTo(RESEND)
+                argThat(new HamcrestArgumentMatcher<>(StatusHistoryEventMatcher.equalTo(RESEND)
                         .withUpdatedDateTime(Matchers.equalTo(NOW.plus(100,  SECONDS))))));
     }
 }

--- a/core/service/src/main/java/uk/gov/dwp/queue/triage/core/service/FailedMessageService.java
+++ b/core/service/src/main/java/uk/gov/dwp/queue/triage/core/service/FailedMessageService.java
@@ -4,12 +4,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.dwp.queue.triage.core.dao.FailedMessageDao;
 import uk.gov.dwp.queue.triage.core.domain.FailedMessage;
-import uk.gov.dwp.queue.triage.core.domain.FailedMessageStatus;
-import uk.gov.dwp.queue.triage.core.domain.FailedMessageStatus.Status;
+import uk.gov.dwp.queue.triage.core.domain.StatusHistoryEvent;
+import uk.gov.dwp.queue.triage.core.domain.StatusHistoryEvent.Status;
 import uk.gov.dwp.queue.triage.id.FailedMessageId;
 
-import static uk.gov.dwp.queue.triage.core.domain.FailedMessageStatus.Status.DELETED;
-import static uk.gov.dwp.queue.triage.core.domain.FailedMessageStatus.failedMessageStatus;
+import static uk.gov.dwp.queue.triage.core.domain.StatusHistoryEvent.Status.DELETED;
+import static uk.gov.dwp.queue.triage.core.domain.StatusHistoryEvent.statusHistoryEvent;
 
 public class FailedMessageService {
 
@@ -26,20 +26,20 @@ public class FailedMessageService {
     }
 
     public void updateStatus(FailedMessageId failedMessageId, Status status) {
-        updateStatus(failedMessageId, failedMessageStatus(status));
+        updateStatus(failedMessageId, statusHistoryEvent(status));
     }
 
-    public void updateStatus(FailedMessageId failedMessageId, FailedMessageStatus failedMessageStatus) {
+    public void updateStatus(FailedMessageId failedMessageId, StatusHistoryEvent statusHistoryEvent) {
         LOGGER.debug("Message {} updated to {} with effectiveDateTime {}",
                 failedMessageId,
-                failedMessageStatus.getStatus(),
-                failedMessageStatus.getEffectiveDateTime()
+                statusHistoryEvent.getStatus(),
+                statusHistoryEvent.getEffectiveDateTime()
         );
-        failedMessageDao.updateStatus(failedMessageId, failedMessageStatus);
+        failedMessageDao.updateStatus(failedMessageId, statusHistoryEvent);
     }
 
     public void delete(FailedMessageId failedMessageId) {
         LOGGER.debug("Message {} deleted", failedMessageId);
-        failedMessageDao.updateStatus(failedMessageId, failedMessageStatus(DELETED));
+        failedMessageDao.updateStatus(failedMessageId, statusHistoryEvent(DELETED));
     }
 }

--- a/core/service/src/test/java/uk/gov/dwp/queue/triage/core/service/FailedMessageServiceTest.java
+++ b/core/service/src/test/java/uk/gov/dwp/queue/triage/core/service/FailedMessageServiceTest.java
@@ -6,14 +6,14 @@ import org.mockito.Mockito;
 import org.mockito.internal.hamcrest.HamcrestArgumentMatcher;
 import uk.gov.dwp.queue.triage.core.dao.FailedMessageDao;
 import uk.gov.dwp.queue.triage.core.domain.FailedMessage;
-import uk.gov.dwp.queue.triage.core.domain.FailedMessageStatus;
-import uk.gov.dwp.queue.triage.core.domain.FailedMessageStatusMatcher;
+import uk.gov.dwp.queue.triage.core.domain.StatusHistoryEvent;
+import uk.gov.dwp.queue.triage.core.domain.StatusHistoryEventMatcher;
 import uk.gov.dwp.queue.triage.id.FailedMessageId;
 
 import java.time.Instant;
 
-import static uk.gov.dwp.queue.triage.core.domain.FailedMessageStatus.Status.DELETED;
-import static uk.gov.dwp.queue.triage.core.domain.FailedMessageStatus.Status.RESEND;
+import static uk.gov.dwp.queue.triage.core.domain.StatusHistoryEvent.Status.DELETED;
+import static uk.gov.dwp.queue.triage.core.domain.StatusHistoryEvent.Status.RESEND;
 
 public class FailedMessageServiceTest {
 
@@ -38,17 +38,17 @@ public class FailedMessageServiceTest {
 
         Mockito.verify(failedMessageDao).updateStatus(
                 Mockito.eq(FAILED_MESSAGE_ID),
-                argThat(FailedMessageStatusMatcher.equalTo(RESEND).withUpdatedDateTime(Matchers.notNullValue(Instant.class)))
+                argThat(StatusHistoryEventMatcher.equalTo(RESEND).withUpdatedDateTime(Matchers.notNullValue(Instant.class)))
         );
     }
 
     @Test
     public void updateStatusWithGivenDate() {
-        underTest.updateStatus(FAILED_MESSAGE_ID, new FailedMessageStatus(RESEND, NOW));
+        underTest.updateStatus(FAILED_MESSAGE_ID, new StatusHistoryEvent(RESEND, NOW));
 
         Mockito.verify(failedMessageDao).updateStatus(
                 Mockito.eq(FAILED_MESSAGE_ID),
-                argThat(FailedMessageStatusMatcher.equalTo(RESEND).withUpdatedDateTime(Matchers.equalTo(NOW)))
+                argThat(StatusHistoryEventMatcher.equalTo(RESEND).withUpdatedDateTime(Matchers.equalTo(NOW)))
         );
     }
 
@@ -58,11 +58,11 @@ public class FailedMessageServiceTest {
 
         Mockito.verify(failedMessageDao).updateStatus(
                 Mockito.eq(FAILED_MESSAGE_ID),
-                argThat(FailedMessageStatusMatcher.equalTo(DELETED).withUpdatedDateTime(Matchers.notNullValue(Instant.class)))
+                argThat(StatusHistoryEventMatcher.equalTo(DELETED).withUpdatedDateTime(Matchers.notNullValue(Instant.class)))
         );
     }
 
-    public FailedMessageStatus argThat(FailedMessageStatusMatcher matcher) {
+    public StatusHistoryEvent argThat(StatusHistoryEventMatcher matcher) {
         return Mockito.argThat(new HamcrestArgumentMatcher<>(matcher));
     }
 }


### PR DESCRIPTION
Simple rename of FailedMessageStatus to StatusHistoryEvent.

NOTE: This should NOT a breaking change, the `FailedMessageStatus` is only used internally in `queue-triage-core`