### PR TITLE
Introduce endpoint to get Status History for a FailedMessage

### DIFF
--- a/common/cxf/BUCK
+++ b/common/cxf/BUCK
@@ -11,6 +11,7 @@ java_library(
         "//common/swagger:queue-triage-common-swagger-cxf",
         "//core/activemq:queue-triage-core-activemq",
         "//core/resend:queue-triage-core-resend-spring",
+        "//core/sample-data:queue-triage-sample-data",
         "//core/server:queue-triage-core-server",
         "//core/message-classification:queue-triage-core-message-classification-server",
         "//web/mustache:queue-triage-web-mustache-spring",

--- a/core/client-test-support/src/main/java/uk/gov/dwp/queue/triage/core/client/StatusHistoryResponseMatcher.java
+++ b/core/client-test-support/src/main/java/uk/gov/dwp/queue/triage/core/client/StatusHistoryResponseMatcher.java
@@ -1,0 +1,50 @@
+package uk.gov.dwp.queue.triage.core.domain;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+import uk.gov.dwp.queue.triage.core.client.FailedMessageStatus;
+import uk.gov.dwp.queue.triage.core.client.status.StatusHistoryResponse;
+
+import java.time.Instant;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+
+public class StatusHistoryResponseMatcher extends TypeSafeDiagnosingMatcher<StatusHistoryResponse> {
+
+    private Matcher<FailedMessageStatus> status = notNullValue(FailedMessageStatus.class);
+    private Matcher<Instant> effectiveDateTime = notNullValue(Instant.class);
+
+    public static StatusHistoryResponseMatcher statusHistoryResponse() {
+        return new StatusHistoryResponseMatcher();
+    }
+
+    @Override
+    protected boolean matchesSafely(StatusHistoryResponse statusHistoryResponse, Description description) {
+        final FailedMessageStatus status = statusHistoryResponse.getStatus();
+        final Instant effectiveDateTime = statusHistoryResponse.getEffectiveDateTime();
+        description
+                .appendText("status = ").appendValue(status)
+                .appendText(", effectiveDateTime = ").appendValue(effectiveDateTime);
+        return this.status.matches(status) &&
+                this.effectiveDateTime.matches(effectiveDateTime);
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description
+                .appendText("status is ").appendValue(status)
+                .appendText(", effectiveDateTime is ").appendValue(effectiveDateTime);
+    }
+
+    public StatusHistoryResponseMatcher withStatus(FailedMessageStatus status) {
+        this.status = equalTo(status);
+        return this;
+    }
+
+    public StatusHistoryResponseMatcher withEffectiveDateTime(Instant statusDateTime) {
+        this.effectiveDateTime = equalTo(statusDateTime);
+        return this;
+    }
+}

--- a/core/client/BUCK
+++ b/core/client/BUCK
@@ -17,6 +17,7 @@ java_library(
         "//core/domain:test",
         "//core/resend:queue-triage-core-resend",
         "//core/resend:test",
+        "//core/sample-data:queue-triage-sample-data",
         "//core/search:queue-triage-core-search",
         "//core/search:queue-triage-core-search-mongo",
         "//core/search:test-mongo",

--- a/core/client/src/main/java/uk/gov/dwp/queue/triage/core/client/status/FailedMessageStatusHistoryClient.java
+++ b/core/client/src/main/java/uk/gov/dwp/queue/triage/core/client/status/FailedMessageStatusHistoryClient.java
@@ -1,0 +1,24 @@
+package uk.gov.dwp.queue.triage.core.client.status;
+
+import io.swagger.annotations.Api;
+import uk.gov.dwp.queue.triage.id.FailedMessageId;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+
+import java.util.List;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+@Api(value = "status-history")
+@Consumes(APPLICATION_JSON)
+@Produces(APPLICATION_JSON)
+@Path("/failed-message/${failedMessageId}/status-history")
+public interface FailedMessageStatusHistoryClient {
+
+    @GET
+    List<StatusHistoryResponse> getStatusHistory(@PathParam("failedMessageId") FailedMessageId failedMessageId);
+}

--- a/core/client/src/main/java/uk/gov/dwp/queue/triage/core/client/status/StatusHistoryResponse.java
+++ b/core/client/src/main/java/uk/gov/dwp/queue/triage/core/client/status/StatusHistoryResponse.java
@@ -1,0 +1,39 @@
+package uk.gov.dwp.queue.triage.core.client.status;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.dwp.queue.triage.core.client.FailedMessageStatus;
+
+import javax.validation.constraints.NotNull;
+import java.time.Instant;
+
+public class StatusHistoryResponse {
+
+    @NotNull
+    @JsonProperty
+    private final FailedMessageStatus status;
+    @NotNull
+    @JsonProperty
+    private final Instant effectiveDateTime;
+
+    public StatusHistoryResponse(@JsonProperty("status") FailedMessageStatus status,
+                                 @JsonProperty("effectiveDateTime") Instant effectiveDateTime) {
+        this.status = status;
+        this.effectiveDateTime = effectiveDateTime;
+    }
+
+    public FailedMessageStatus getStatus() {
+        return status;
+    }
+
+    public Instant getEffectiveDateTime() {
+        return effectiveDateTime;
+    }
+
+    @Override
+    public String toString() {
+        return "StatusHistoryResponse{" +
+                "status=" + status +
+                ", effectiveDateTime=" + effectiveDateTime +
+                '}';
+    }
+}

--- a/core/component-test/src/main/java/uk/gov/dwp/queue/triage/core/status/StatusHistoryStage.java
+++ b/core/component-test/src/main/java/uk/gov/dwp/queue/triage/core/status/StatusHistoryStage.java
@@ -1,0 +1,58 @@
+package uk.gov.dwp.queue.triage.core.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tngtech.jgiven.Stage;
+import com.tngtech.jgiven.annotation.ExpectedScenarioState;
+import com.tngtech.jgiven.integration.spring.JGivenStage;
+import org.hamcrest.Matcher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageResponse;
+import uk.gov.dwp.queue.triage.core.client.status.StatusHistoryResponse;
+import uk.gov.dwp.queue.triage.core.search.SearchFailedMessageStage;
+import uk.gov.dwp.queue.triage.id.FailedMessageId;
+
+import javax.ws.rs.core.Response;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@JGivenStage
+public class StatusHistoryStage extends Stage<StatusHistoryStage> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SearchFailedMessageStage.class);
+
+    @Autowired
+    private TestRestTemplate testRestTemplate;
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @ExpectedScenarioState
+    private ResponseEntity<List<StatusHistoryResponse>> response;
+
+    public StatusHistoryStage theStatusHistoryIsRequestedFor(FailedMessageId failedMessageId) {
+        response = testRestTemplate.exchange(
+                "/core/failed-message/${failedMessageId}/status-history",
+                HttpMethod.GET,
+                HttpEntity.EMPTY,
+                new ParameterizedTypeReference<List<StatusHistoryResponse>>() {},
+                Collections.singletonMap("failedMessageId", failedMessageId)
+        );
+        return this;
+    }
+
+    public StatusHistoryStage theStatusHistory(Matcher<Iterable<? extends StatusHistoryResponse>> resultsMatcher) {
+        assertThat(response.getStatusCodeValue(), is(Response.Status.OK.getStatusCode()));
+        assertThat(response.getBody(), resultsMatcher);
+        return this;
+    }
+}

--- a/core/component-test/src/test/java/uk/gov/dwp/queue/triage/core/search/SearchFailedMessageComponentTest.java
+++ b/core/component-test/src/test/java/uk/gov/dwp/queue/triage/core/search/SearchFailedMessageComponentTest.java
@@ -26,7 +26,7 @@ public class SearchFailedMessageComponentTest extends BaseCoreComponentTest<Sear
     private FailedMessageResourceStage failedMessageResourceStage;
 
     @Test
-    public void searchByBrokerResultsNoResultsWhenNoFailedMessagesExist() throws Exception {
+    public void searchByBrokerResultsNoResultsWhenNoFailedMessagesExist() {
 
         when().aSearchIsRequested(searchMatchingAllCriteria()
                 .withBroker("broker-name"));

--- a/core/component-test/src/test/java/uk/gov/dwp/queue/triage/core/status/FailedMessageStatusHistoryComponentTest.java
+++ b/core/component-test/src/test/java/uk/gov/dwp/queue/triage/core/status/FailedMessageStatusHistoryComponentTest.java
@@ -1,0 +1,32 @@
+package uk.gov.dwp.queue.triage.core.status;
+
+import com.tngtech.jgiven.annotation.ScenarioStage;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import uk.gov.dwp.queue.triage.core.BaseCoreComponentTest;
+import uk.gov.dwp.queue.triage.core.FailedMessageResourceStage;
+import uk.gov.dwp.queue.triage.core.client.FailedMessageStatus;
+import uk.gov.dwp.queue.triage.id.FailedMessageId;
+
+import static uk.gov.dwp.queue.triage.core.client.CreateFailedMessageRequest.newCreateFailedMessageRequest;
+import static uk.gov.dwp.queue.triage.core.domain.StatusHistoryResponseMatcher.statusHistoryResponse;
+
+public class FailedMessageStatusHistoryComponentTest extends BaseCoreComponentTest<StatusHistoryStage> {
+
+    @ScenarioStage
+    private FailedMessageResourceStage failedMessageResourceStage;
+
+    @Test
+    public void name() {
+        FailedMessageId failedMessageId = FailedMessageId.newFailedMessageId();
+        failedMessageResourceStage.given().aFailedMessage(newCreateFailedMessageRequest()
+                .withFailedMessageId(failedMessageId)
+                .withBrokerName("broker-name")
+                .withDestinationName("queue-name"))
+                .exists();
+        when().theStatusHistoryIsRequestedFor(failedMessageId);
+        then().theStatusHistory(Matchers.contains(
+                statusHistoryResponse().withStatus(FailedMessageStatus.FAILED)
+        ));
+    }
+}

--- a/core/domain/src/main/java/uk/gov/dwp/queue/triage/core/domain/StatusHistoryEvent.java
+++ b/core/domain/src/main/java/uk/gov/dwp/queue/triage/core/domain/StatusHistoryEvent.java
@@ -5,15 +5,15 @@ import java.time.Instant;
 public class StatusHistoryEvent {
 
     private final Status status;
-    private final Instant updatedDateTime;
+    private final Instant effectiveDateTimme;
 
     public static StatusHistoryEvent statusHistoryEvent(Status status) {
         return new StatusHistoryEvent(status, Instant.now());
     }
 
-    public StatusHistoryEvent(Status status, Instant updatedDateTime) {
+    public StatusHistoryEvent(Status status, Instant effectiveDateTimme) {
         this.status = status;
-        this.updatedDateTime = updatedDateTime;
+        this.effectiveDateTimme = effectiveDateTimme;
     }
 
     public Status getStatus() {
@@ -21,7 +21,7 @@ public class StatusHistoryEvent {
     }
 
     public Instant getEffectiveDateTime() {
-        return updatedDateTime;
+        return effectiveDateTimme;
     }
 
     public enum Status {

--- a/core/sample-data/BUCK
+++ b/core/sample-data/BUCK
@@ -1,0 +1,18 @@
+java_library(
+    name = 'queue-triage-sample-data',
+    srcs = glob(["src/main/java/**/*.java"]),
+    deps = [
+        '//common/id:queue-triage-common-id',
+        '//common/cxf:queue-triage-common-cxf',
+        '//common/jackson:queue-triage-common-jackson',
+        '//common/jackson:queue-triage-common-jackson-spring',
+        '//core/client:queue-triage-core-client',
+        '//lib/apache-cxf:cxf-rt-rs-client',
+        '//lib/apache-cxf:cxf-rt-transports-http-jetty',
+        '//lib:commons-lang3',
+        '//lib/jackson:jackson-annotations',
+        '//lib/javax:javax-validation-api',
+        '//lib/javax:javax-ws-rs-api',
+        '//lib/swagger:swagger-annotations',
+    ],
+)

--- a/core/sample-data/src/main/java/uk/gov/dwp/queue/triage/sample/data/create/CreateFailedMessages.java
+++ b/core/sample-data/src/main/java/uk/gov/dwp/queue/triage/sample/data/create/CreateFailedMessages.java
@@ -1,0 +1,58 @@
+package uk.gov.dwp.queue.triage.sample.data.create;
+
+import org.apache.cxf.jaxrs.client.JAXRSClientFactory;
+import uk.gov.dwp.queue.triage.core.client.CreateFailedMessageClient;
+import uk.gov.dwp.queue.triage.core.client.CreateFailedMessageRequest;
+import uk.gov.dwp.queue.triage.core.client.CreateFailedMessageRequest.CreateFailedMessageRequestBuilder;
+import uk.gov.dwp.queue.triage.core.client.SearchFailedMessageClient;
+import uk.gov.dwp.queue.triage.cxf.CxfConfiguration;
+import uk.gov.dwp.queue.triage.id.FailedMessageId;
+import uk.gov.dwp.queue.triage.jackson.configuration.JacksonConfiguration;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import static java.util.Collections.singletonList;
+
+public class CreateFailedMessages {
+
+    private final CreateFailedMessageClient createFailedMessageClient;
+
+    public CreateFailedMessages(CreateFailedMessageClient createFailedMessageClient) {
+        this.createFailedMessageClient = createFailedMessageClient;
+    }
+
+    public void createFailedMessages(int numberOfMessages,
+                                     CreateFailedMessageRequestBuilder createFailedMessageRequestBuilder) {
+        for (int i=0; i<numberOfMessages; i++) {
+            createFailedMessageClient.create(createFailedMessageRequestBuilder
+                    .withFailedMessageId(FailedMessageId.newFailedMessageId())
+                    .withFailedDateTime(Instant.now())
+                    .withContent("{ \"id\": \"" + UUID.randomUUID() + "\", \"action\": \"DELETE\" }")
+                    .build()
+            );
+        }
+    }
+
+    public static void main(String[] args) {
+        final JacksonConfiguration jacksonConfiguration = new JacksonConfiguration();
+        final CreateFailedMessages createFailedMessages = new CreateFailedMessages(
+                JAXRSClientFactory.create(
+                        "http://localhost:9991/core",
+                        CreateFailedMessageClient.class,
+                        singletonList(jacksonConfiguration.jacksonJsonProvider(
+                                new CxfConfiguration(), jacksonConfiguration.objectMapper()
+                        ))
+                )
+        );
+        createFailedMessages.createFailedMessages(
+                5,
+                CreateFailedMessageRequest.newCreateFailedMessageRequest()
+                        .withBrokerName("internal-broker")
+                        .withDestinationName("core.queue")
+                        .withProperty("traceId", UUID.randomUUID())
+                        .withProperty("retries", 1)
+        );
+    }
+
+}

--- a/core/server/src/main/java/uk/gov/dwp/queue/triage/core/configuration/FailedMessageResourceConfiguration.java
+++ b/core/server/src/main/java/uk/gov/dwp/queue/triage/core/configuration/FailedMessageResourceConfiguration.java
@@ -3,6 +3,7 @@ package uk.gov.dwp.queue.triage.core.configuration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import uk.gov.dwp.queue.triage.core.resource.status.FailedMessageStatusHistoryResource;
 import uk.gov.dwp.queue.triage.cxf.CxfConfiguration;
 import uk.gov.dwp.queue.triage.cxf.ResourceRegistry;
 import uk.gov.dwp.queue.triage.core.dao.FailedMessageDao;
@@ -60,5 +61,11 @@ public class FailedMessageResourceConfiguration {
         return resourceRegistry.add(new LabelFailedMessageResource(
                 failedMessageLabelService
         ));
+    }
+
+    @Bean
+    public FailedMessageStatusHistoryResource failedMessageStatusHistoryResource(ResourceRegistry resourceRegistry,
+                                                                                 FailedMessageDao failedMessageDao) {
+        return resourceRegistry.add(new FailedMessageStatusHistoryResource(failedMessageDao));
     }
 }

--- a/core/server/src/main/java/uk/gov/dwp/queue/triage/core/resource/status/FailedMessageStatusHistoryResource.java
+++ b/core/server/src/main/java/uk/gov/dwp/queue/triage/core/resource/status/FailedMessageStatusHistoryResource.java
@@ -1,0 +1,36 @@
+package uk.gov.dwp.queue.triage.core.resource.status;
+
+import uk.gov.dwp.queue.triage.core.client.FailedMessageStatus;
+import uk.gov.dwp.queue.triage.core.client.status.FailedMessageStatusHistoryClient;
+import uk.gov.dwp.queue.triage.core.client.status.StatusHistoryResponse;
+import uk.gov.dwp.queue.triage.core.dao.FailedMessageDao;
+import uk.gov.dwp.queue.triage.core.domain.StatusHistoryEvent;
+import uk.gov.dwp.queue.triage.id.FailedMessageId;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static uk.gov.dwp.queue.triage.core.domain.FailedMessageStatusAdapter.toFailedMessageStatus;
+
+public class FailedMessageStatusHistoryResource implements FailedMessageStatusHistoryClient {
+
+    private final FailedMessageDao failedMessageDao;
+
+    public FailedMessageStatusHistoryResource(FailedMessageDao failedMessageDao) {
+        this.failedMessageDao = failedMessageDao;
+    }
+
+    @Override
+    public List<StatusHistoryResponse> getStatusHistory(FailedMessageId failedMessageId) {
+        final List<StatusHistoryResponse> statusHistoryResponses = new ArrayList<>();
+        final List<StatusHistoryEvent> statusHistory = failedMessageDao.getStatusHistory(failedMessageId);
+        for (int i=0; i<statusHistory.size(); i++) {
+            final FailedMessageStatus failedMessageStatus = toFailedMessageStatus(statusHistory.get(i).getStatus());
+            if (i+1<statusHistory.size() && failedMessageStatus.equals(toFailedMessageStatus(statusHistory.get(i+1).getStatus()))) {
+                i++;
+            }
+            statusHistoryResponses.add(new StatusHistoryResponse(failedMessageStatus, statusHistory.get(i).getEffectiveDateTime()));
+        }
+        return statusHistoryResponses;
+    }
+}

--- a/core/server/src/test/java/uk/gov/dwp/queue/triage/core/resource/search/FailedMessageResponseFactoryTest.java
+++ b/core/server/src/test/java/uk/gov/dwp/queue/triage/core/resource/search/FailedMessageResponseFactoryTest.java
@@ -25,7 +25,7 @@ public class FailedMessageResponseFactoryTest {
     private final FailedMessageResponseFactory underTest = new FailedMessageResponseFactory(new FailedMessageStatusAdapter());
 
     @Test
-    public void createFailedMessageResponseFromAFailedMessage() throws Exception {
+    public void createFailedMessageResponseFromAFailedMessage() {
 
         FailedMessageResponse failedMessageResponse = underTest.create(newFailedMessage()
                 .withContent("Hello World")

--- a/core/server/src/test/java/uk/gov/dwp/queue/triage/core/resource/status/FailedMessageStatusHistoryResourceTest.java
+++ b/core/server/src/test/java/uk/gov/dwp/queue/triage/core/resource/status/FailedMessageStatusHistoryResourceTest.java
@@ -1,0 +1,72 @@
+package uk.gov.dwp.queue.triage.core.resource.status;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import uk.gov.dwp.queue.triage.core.dao.FailedMessageDao;
+import uk.gov.dwp.queue.triage.core.domain.StatusHistoryEvent;
+import uk.gov.dwp.queue.triage.id.FailedMessageId;
+
+import java.time.Instant;
+import java.util.Arrays;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.mockito.Mockito.when;
+import static uk.gov.dwp.queue.triage.core.client.FailedMessageStatus.FAILED;
+import static uk.gov.dwp.queue.triage.core.client.FailedMessageStatus.SENT;
+import static uk.gov.dwp.queue.triage.core.domain.StatusHistoryResponseMatcher.statusHistoryResponse;
+
+public class FailedMessageStatusHistoryResourceTest {
+
+    private static final FailedMessageId FAILED_MESSAGE_ID = FailedMessageId.newFailedMessageId();
+    private static final Instant NOW = Instant.now();
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+    @Mock
+    private FailedMessageDao failedMessageDao;
+    private FailedMessageStatusHistoryResource underTest;
+
+    @Before
+    public void setUp() {
+        underTest = new FailedMessageStatusHistoryResource(failedMessageDao);
+    }
+
+    @Test
+    public void failedMessageWithStatusHistoryEntries() {
+        when(failedMessageDao.getStatusHistory(FAILED_MESSAGE_ID)).thenReturn(Arrays.asList(
+                new StatusHistoryEvent(StatusHistoryEvent.Status.FAILED, NOW),
+                new StatusHistoryEvent(StatusHistoryEvent.Status.SENT, NOW.plusSeconds(1))
+        ));
+        assertThat(underTest.getStatusHistory(FAILED_MESSAGE_ID), contains(
+                statusHistoryResponse().withStatus(FAILED).withEffectiveDateTime(NOW),
+                statusHistoryResponse().withStatus(SENT).withEffectiveDateTime(NOW.plusSeconds(1))
+        ));
+    }
+
+    // FAILED & CLASSIFIED -> FAILED
+
+    @Test
+    public void responseOnlyContainsASingleEntryWhenFailedAndClassifiedStatusAreConcurrent() {
+        when(failedMessageDao.getStatusHistory(FAILED_MESSAGE_ID)).thenReturn(Arrays.asList(
+                new StatusHistoryEvent(StatusHistoryEvent.Status.FAILED, NOW),
+                new StatusHistoryEvent(StatusHistoryEvent.Status.CLASSIFIED, NOW.plusSeconds(1))
+        ));
+        assertThat(underTest.getStatusHistory(FAILED_MESSAGE_ID), contains(
+                statusHistoryResponse().withStatus(FAILED).withEffectiveDateTime(NOW.plusSeconds(1))
+        ));
+    }
+
+    @Test
+    public void singleStatusHistoryEntry() {
+        when(failedMessageDao.getStatusHistory(FAILED_MESSAGE_ID)).thenReturn(Arrays.asList(
+                new StatusHistoryEvent(StatusHistoryEvent.Status.CLASSIFIED, NOW)
+        ));
+        assertThat(underTest.getStatusHistory(FAILED_MESSAGE_ID), contains(
+                statusHistoryResponse().withStatus(FAILED).withEffectiveDateTime(NOW)
+        ));
+    }
+}

--- a/lib/apache-cxf/BUCK
+++ b/lib/apache-cxf/BUCK
@@ -7,6 +7,7 @@ prebuilt_jar(
     binary_jar = ":cxf-rt-rs-client-mvn",
     visibility = [
         "//core/component-test:",
+        "//core/sample-data:queue-triage-sample-data",
         "//web/server:queue-triage-web-server",
     ],
 )
@@ -66,6 +67,7 @@ java_library(
     visibility = [
         "//common/cxf-server:queue-triage-common-cxf-server",
         "//core/component-test:test",
+        "//core/sample-data:queue-triage-sample-data",
         "//core/server:queue-triage-core-server",
     ]
 )


### PR DESCRIPTION
- Introduced an endpoint to get Status History for a Failed Message (see `FailedMessageStatusHistoryClient` for details of the API)
- Added a class `CreateFailedMessages` (in the `queue-triage-sample-data` module) to generate test data via the REST API