### PR TITLE
#100: Externalise LDAP configuration

### DIFF
--- a/core/server/src/main/resources/logback.xml
+++ b/core/server/src/main/resources/logback.xml
@@ -3,7 +3,7 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS,Z} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
 

--- a/lib/spring/BUCK
+++ b/lib/spring/BUCK
@@ -4,6 +4,7 @@ prebuilt_jar(
     binary_jar=':spring-beans-mvn',
     source_jar=":spring-beans-src",
     visibility=["PUBLIC"])
+
 prebuilt_jar(
     name="spring-boot",
     binary_jar = ":spring-boot-mvn",
@@ -17,6 +18,7 @@ prebuilt_jar(
         "//core/message-classification:queue-triage-core-message-classification-server",
         "//core/message-classification:test-server",
         "//core/search:queue-triage-core-search-mongo-spring",
+        "//web/spring-security:queue-triage-web-spring-security-ldap",
     ]
 )
 prebuilt_jar(name="spring-boot-autoconfigure", binary_jar = ":spring-boot-autoconfigure-mvn", visibility=["PUBLIC"])
@@ -123,6 +125,7 @@ java_library(
         "//web/component-test:queue-triage-web-component-test",
         "//web/component-test:test",
         "//web/server:queue-triage-web-server",
+        "//web/spring-security:ldap-test",
     ],
 )
 
@@ -157,6 +160,7 @@ java_library(
         "//lib:aopalliance",
     ],
     visibility = [
+        "//web/spring-security:ldap-test",
         "//web/spring-security:queue-triage-web-spring-security",
         "//web/spring-security:queue-triage-web-spring-security-ldap",
     ],

--- a/web/server/src/main/resources/application.yml
+++ b/web/server/src/main/resources/application.yml
@@ -6,4 +6,8 @@ cxf:
 
 client:
   core:
-   url: http://localhost:9991/core
+    url: http://localhost:9991/core
+
+ldap:
+  urls:
+    - ldap://localhost:8389/

--- a/web/server/src/main/resources/logback.xml
+++ b/web/server/src/main/resources/logback.xml
@@ -3,7 +3,7 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS,Z} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
 

--- a/web/spring-security/BUCK
+++ b/web/spring-security/BUCK
@@ -17,9 +17,33 @@ java_library(
     srcs = glob(["src/main/java/**/ldap/*.java"]),
     exported_deps = [
         "//lib/ldap:unboundid-ldapsdk",
+        "//lib/spring:spring-boot",
         "//lib/spring:spring-security-ldap-with-dependencies",
     ],
     visibility = [
         "//web/server:queue-triage-web-server",
+    ],
+)
+
+java_library(
+    name = 'test-resources',
+    resources = glob([
+        'src/test/resources/*.yml'
+    ]),
+    resources_root = 'src/test/resources',
+)
+
+java_test(
+    name = 'ldap-test',
+    srcs = glob(['src/test/java/**/ldap/*.java']),
+    deps = [
+        ':queue-triage-web-spring-security-ldap',
+        ':test-resources',
+        '//lib:snakeyaml',
+        '//lib/spring:spring-security-ldap-with-dependencies',
+        '//lib/spring:spring-boot-test',
+        '//lib/spring:spring-boot-with-dependencies',
+        '//lib/spring:spring-test',
+        '//lib/test:common',
     ],
 )

--- a/web/spring-security/src/main/java/uk/gov/dwp/queue/triage/web/security/spring/ldap/LdapSecurityConfig.java
+++ b/web/spring-security/src/main/java/uk/gov/dwp/queue/triage/web/security/spring/ldap/LdapSecurityConfig.java
@@ -1,5 +1,6 @@
 package uk.gov.dwp.queue.triage.web.security.spring.ldap;
 
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.encoding.PlaintextPasswordEncoder;
@@ -10,25 +11,26 @@ import org.springframework.security.ldap.DefaultSpringSecurityContextSource;
 import static java.util.Collections.singletonList;
 
 @Configuration
+@EnableConfigurationProperties(LdapSecurityProperties.class)
 public class LdapSecurityConfig {
 
     @Bean
-    public SecurityConfigurerAdapter securityConfigurerAdapter() {
+    public SecurityConfigurerAdapter securityConfigurerAdapter(LdapSecurityProperties ldapSecurityProperties) {
         return new LdapAuthenticationProviderConfigurer()
-                .userDnPatterns("uid={0},ou=Users")
-                .groupSearchBase("ou=Groups")
-                .contextSource(contextSource())
+                .userDnPatterns(ldapSecurityProperties.getUserDnPatterns().toArray(new String[0]))
+                .groupSearchBase(ldapSecurityProperties.getGroupSearch().getBase())
+                .contextSource(contextSource(ldapSecurityProperties))
                 .passwordCompare()
 //                .passwordEncoder(new LdapShaPasswordEncoder())
                 .passwordEncoder(new PlaintextPasswordEncoder())
-                .passwordAttribute("userPassword")
+                .passwordAttribute(ldapSecurityProperties.getPassword().getAttribute())
                 .and();
     }
 
     @Bean
-    public DefaultSpringSecurityContextSource contextSource() {
+    public DefaultSpringSecurityContextSource contextSource(LdapSecurityProperties ldapSecurityProperties) {
         return new DefaultSpringSecurityContextSource(
-                singletonList("ldap://localhost:8389/"),
-                "dc=dwp,dc=gov,dc=uk");
+                ldapSecurityProperties.getUrls(),
+                ldapSecurityProperties.getBaseDn());
     }
 }

--- a/web/spring-security/src/main/java/uk/gov/dwp/queue/triage/web/security/spring/ldap/LdapSecurityProperties.java
+++ b/web/spring-security/src/main/java/uk/gov/dwp/queue/triage/web/security/spring/ldap/LdapSecurityProperties.java
@@ -1,0 +1,81 @@
+package uk.gov.dwp.queue.triage.web.security.spring.ldap;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@ConfigurationProperties(prefix = "ldap")
+public class LdapSecurityProperties {
+
+    static final String DEFAULT_BASE_DN = "dc=dwp,dc=gov,dc=uk";
+    static final String DEFAULT_USER_DN_PATTERN = "uid={0},ou=Users";
+    static final String DEFAULT_GROUP_SEARCH_BASE = "ou=Groups";
+    static final String DEFAULT_PASSWORD_ATTRIBUTE = "userPassword";
+    static final String DEFAULT_PASSWORD_ENCODER = "plaintext";
+
+    private List<String> urls = new ArrayList<>();
+    private String baseDn = DEFAULT_BASE_DN;
+    private GroupSearch groupSearch = new GroupSearch();
+    private List<String> userDnPatterns = new ArrayList<String>() {{
+        add(DEFAULT_USER_DN_PATTERN);
+    }};
+    private Password password = new Password();
+
+    public List<String> getUrls() {
+        return urls;
+    }
+
+    public String getBaseDn() {
+        return baseDn;
+    }
+
+    public void setBaseDn(String baseDn) {
+        this.baseDn = baseDn;
+    }
+
+    public GroupSearch getGroupSearch() {
+        return groupSearch;
+    }
+
+    public List<String> getUserDnPatterns() {
+        return userDnPatterns;
+    }
+
+    public Password getPassword() {
+        return password;
+    }
+
+    public static class GroupSearch {
+        private String base = DEFAULT_GROUP_SEARCH_BASE;
+
+        public String getBase() {
+            return base;
+        }
+
+        public void setBase(String base) {
+            this.base = base;
+        }
+    }
+
+    public static class Password {
+        private String attribute = DEFAULT_PASSWORD_ATTRIBUTE;
+        private String encoder = DEFAULT_PASSWORD_ENCODER;
+
+        public String getAttribute() {
+            return attribute;
+        }
+
+        public String getEncoder() {
+            return encoder;
+        }
+
+        public void setAttribute(String attribute) {
+            this.attribute = attribute;
+        }
+
+        public void setEncoder(String encoder) {
+            this.encoder = encoder;
+        }
+    }
+}

--- a/web/spring-security/src/test/java/uk/gov/dwp/queue/triage/web/security/spring/ldap/LdapSecurityPropertiesLoaderTest.java
+++ b/web/spring-security/src/test/java/uk/gov/dwp/queue/triage/web/security/spring/ldap/LdapSecurityPropertiesLoaderTest.java
@@ -1,0 +1,88 @@
+package uk.gov.dwp.queue.triage.web.security.spring.ldap;
+
+import org.junit.Test;
+import org.springframework.beans.factory.config.YamlPropertiesFactoryBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.PropertiesPropertySource;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.core.io.ClassPathResource;
+
+import java.util.Properties;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static uk.gov.dwp.queue.triage.web.security.spring.ldap.LdapSecurityProperties.DEFAULT_BASE_DN;
+import static uk.gov.dwp.queue.triage.web.security.spring.ldap.LdapSecurityProperties.DEFAULT_GROUP_SEARCH_BASE;
+import static uk.gov.dwp.queue.triage.web.security.spring.ldap.LdapSecurityProperties.DEFAULT_PASSWORD_ATTRIBUTE;
+import static uk.gov.dwp.queue.triage.web.security.spring.ldap.LdapSecurityProperties.DEFAULT_PASSWORD_ENCODER;
+import static uk.gov.dwp.queue.triage.web.security.spring.ldap.LdapSecurityProperties.DEFAULT_USER_DN_PATTERN;
+
+public class LdapSecurityPropertiesLoaderTest {
+
+    @Test
+    public void createDefaultLdapConfiguration() {
+        AnnotationConfigApplicationContext applicationContext = createApplicationContext("spring-security-ldap-defaults.yml");
+
+        LdapSecurityProperties properties = applicationContext.getBean(LdapSecurityProperties.class);
+
+        assertThat(properties.getUrls(), contains(
+                "ldap://localhost:1234"
+        ));
+        assertThat(properties.getBaseDn(), equalTo(DEFAULT_BASE_DN));
+        assertThat(properties.getGroupSearch().getBase(), equalTo(DEFAULT_GROUP_SEARCH_BASE));
+        assertThat(properties.getPassword().getAttribute(), equalTo(DEFAULT_PASSWORD_ATTRIBUTE));
+        assertThat(properties.getPassword().getEncoder(), equalTo(DEFAULT_PASSWORD_ENCODER));
+        assertThat(properties.getUserDnPatterns(), contains(
+                DEFAULT_USER_DN_PATTERN
+        ));
+    }
+
+    @Test
+    public void createFullConfiguration() {
+        AnnotationConfigApplicationContext applicationContext = createApplicationContext("spring-security-ldap-full.yml");
+
+        LdapSecurityProperties properties = applicationContext.getBean(LdapSecurityProperties.class);
+
+        assertThat(properties.getUrls(), contains(
+                "ldap://localhost:888/",
+                "ldap://localhost:999/"
+        ));
+        assertThat(properties.getBaseDn(), equalTo("dc=example,dc=com"));
+        assertThat(properties.getGroupSearch().getBase(), equalTo("ou=Support"));
+        assertThat(properties.getPassword().getAttribute(), equalTo("pw"));
+        assertThat(properties.getPassword().getEncoder(), equalTo("sha256"));
+        assertThat(properties.getUserDnPatterns(), contains(
+                "uid={0},ou=SupportUsers",
+                "uid={0},ou=Admins"
+        ));
+    }
+
+    private AnnotationConfigApplicationContext createApplicationContext(String yamlFilename) {
+        AnnotationConfigApplicationContext applicationContext = new AnnotationConfigApplicationContext();
+        applicationContext.setEnvironment(createEnvironment(yamlFilename));
+        applicationContext.register(DummyConfiguration.class);
+        applicationContext.refresh();
+        return applicationContext;
+    }
+
+    private StandardEnvironment createEnvironment(String yamlFilename) {
+        StandardEnvironment environment = new StandardEnvironment();
+        environment.getPropertySources().addFirst(new PropertiesPropertySource("ldap-properties", loadPropertiesFromYaml(yamlFilename)));
+        return environment;
+    }
+
+    public Properties loadPropertiesFromYaml(String yamlFilename) {
+        YamlPropertiesFactoryBean yamlPropertiesFactoryBean = new YamlPropertiesFactoryBean();
+        yamlPropertiesFactoryBean.setResources(new ClassPathResource(yamlFilename));
+        return yamlPropertiesFactoryBean.getObject();
+    }
+
+    @Configuration
+    @EnableConfigurationProperties(LdapSecurityProperties.class)
+    public static class DummyConfiguration {
+
+    }
+}

--- a/web/spring-security/src/test/resources/spring-security-ldap-defaults.yml
+++ b/web/spring-security/src/test/resources/spring-security-ldap-defaults.yml
@@ -1,0 +1,3 @@
+ldap:
+  urls:
+    - ldap://localhost:1234

--- a/web/spring-security/src/test/resources/spring-security-ldap-full.yml
+++ b/web/spring-security/src/test/resources/spring-security-ldap-full.yml
@@ -1,0 +1,13 @@
+ldap:
+  urls:
+    - ldap://localhost:888/
+    - ldap://localhost:999/
+  baseDn: dc=example,dc=com
+  groupSearch:
+    base: ou=Support
+  userDnPatterns:
+    - uid={0},ou=SupportUsers
+    - uid={0},ou=Admins
+  password:
+    attribute: pw
+    encoder: sha256


### PR DESCRIPTION
Ensure that the configuration for ldap can be configured in the `application.yml` file.

Resolves #100 