### PR TITLE
Issue 102 - Improve test stability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,14 @@
 sudo: false
 dist: trusty
+
 jdk:
   - openjdk8
+
+env:
+  - MOZ_HEADLESS=1
+
+addons:
+  firefox: latest
 
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,7 @@
-sudo: false
-dist: trusty
+sudo: true
 
 jdk:
   - openjdk8
-
-env:
-  - MOZ_HEADLESS=1
 
 addons:
   firefox: latest
@@ -25,6 +21,9 @@ before_script:
   - export PATH=$HOME/buck/bin:$PATH
   # Verify Buck installation
   - buck --version
+  # Start Firefox
+  - docker run -d --net=host -v /dev/shm:/dev/shm selenium/standalone-firefox:3.8.1-francium
+  - docker ps
 
 script:
   - buck build //core/dao-mongo:create-users-and-roles
@@ -33,4 +32,4 @@ script:
 
 services:
   - mongodb
-
+  - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ sudo: true
 jdk:
   - openjdk8
 
-addons:
-  firefox: latest
-
 notifications:
   slack:
     rooms:
@@ -28,7 +25,8 @@ before_script:
 script:
   - buck build //core/dao-mongo:create-users-and-roles
   - buck fetch //... > /dev/null
-  - buck test //... > /dev/null
+  - buck test --all --exclude component-test > /dev/null
+  - buck test --all --include component-test > /dev/null
 
 services:
   - mongodb

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ buck build //core/dao-mongo:create-users-and-roles
 To build and test all the modules run the following commands:
 
 ```bash
-buck test //...
+buck test --all --exclude component-test
+buck test --all --include component-test
 ```
 
 To run the `queue-triage-core-server` from the command line run:

--- a/core/component-test/BUCK
+++ b/core/component-test/BUCK
@@ -46,6 +46,9 @@ java_library(
 
 java_test(
     name = "test",
+    labels = [
+        "component-test"
+    ],
     srcs = glob(['src/test/java/**/*Test.java']),
     deps = [
         "//lib/hibernate-validator:hibernate-validator",

--- a/lib/httpcomponents/BUCK
+++ b/lib/httpcomponents/BUCK
@@ -7,9 +7,9 @@ prebuilt_jar(
 )
 remote_file(
     name = "httpcore-mvn",
-    out  = "httpcore-4.4.6.jar",
-    url  = "mvn:org.apache.httpcomponents:httpcore:jar:4.4.6",
-    sha1 = "e3fd8ced1f52c7574af952e2e6da0df8df08eb82",
+    out  = "httpcore-4.4.9.jar",
+    url  = "mvn:org.apache.httpcomponents:httpcore:jar:4.4.9",
+    sha1 = "a86ce739e5a7175b4b234c290a00a5fdb80957a0",
 )
 
 prebuilt_jar(

--- a/lib/selenide/BUCK
+++ b/lib/selenide/BUCK
@@ -9,15 +9,15 @@ prebuilt_jar(
 )
 remote_file(
     name = "selenide-mvn",
-    out = "selenide-4.5.1.jar",
-    url = "mvn:com.codeborne:selenide:jar:4.5.1",
-    sha1 = "c99b650f98572adbc331fda2cb5b7b77a0a52608"
+    out = "selenide-4.10.01.jar",
+    url = "mvn:com.codeborne:selenide:jar:4.10.01",
+    sha1 = "0da96cb7059ef961697b530370812125b6af08c0"
 )
 remote_file(
     name = "selenide-src-mvn",
-    out = "selenide-4.5.1-sources.jar",
-    url = "mvn:com.codeborne:selenide:src:4.5.1",
-    sha1 = "0dfb82c2bc9aa2e22a4bf528b3a4e707544ba687"
+    out = "selenide-4.10.01-sources.jar",
+    url = "mvn:com.codeborne:selenide:src:4.10.01",
+    sha1 = "ede986aeeddabce90709794c5f789617b6447db7"
 )
 
 

--- a/lib/selenium/BUCK
+++ b/lib/selenium/BUCK
@@ -8,8 +8,8 @@ prebuilt_jar(
 remote_file(
     name = "selenium-java-mvn",
     out  = "selenium-java-3.4.0.jar",
-    url  = "mvn:org.seleniumhq.selenium:selenium-java:jar:3.4.0",
-    sha1 = "2b8e09636cefdb164eec61534482af5e505d051e"
+    url  = "mvn:org.seleniumhq.selenium:selenium-java:jar:3.8.1",
+    sha1 = "05b50d4072e0e51779b6e9f3594106312061bfde"
 )
 
 prebuilt_jar(
@@ -23,9 +23,9 @@ prebuilt_jar(
 )
 remote_file(
     name = "selenium-api-mvn",
-    out = "selenium-api-3.4.0.jar",
-    url = "mvn:org.seleniumhq.selenium:selenium-api:jar:3.4.0",
-    sha1 = "bf91d238e6eb07f8496ccb61e12e2c868d2bc7e9"
+    out = "selenium-api-3.8.1.jar",
+    url = "mvn:org.seleniumhq.selenium:selenium-api:jar:3.8.1",
+    sha1 = "248cdab497e53be8a259ac7edea3e82df2aa6cef"
 )
 
 prebuilt_jar(
@@ -38,9 +38,9 @@ prebuilt_jar(
 )
 remote_file(
     name = "selenium-remote-driver-mvn",
-    out  = "selenium-remote-driver-3.4.0.jar",
-    url  = "mvn:org.seleniumhq.selenium:selenium-remote-driver:jar:3.4.0",
-    sha1 = "2593094fccb4f0317e211674ebfc22fb049c043a"
+    out  = "selenium-remote-driver-3.8.1.jar",
+    url  = "mvn:org.seleniumhq.selenium:selenium-remote-driver:jar:3.8.1",
+    sha1 = "f2e493ccd447e36c7bb97bd3d872ed1d7dada6cf"
 )
 
 prebuilt_jar(
@@ -53,7 +53,7 @@ prebuilt_jar(
 )
 remote_file(
     name = "selenium-support-mvn",
-    out  = "selenium-support-3.4.0.jar",
-    url  = "mvn:org.seleniumhq.selenium:selenium-support:jar:3.4.0",
-    sha1 = "0900176a308fbf55d741a168a3beac8527caf1c1",
+    out  = "selenium-support-3.8.1.jar",
+    url  = "mvn:org.seleniumhq.selenium:selenium-support:jar:3.8.1",
+    sha1 = "a81051b31220c6f4a56d19d35c5cdeb081026dfa",
 )

--- a/lib/selenium/firefox-driver/BUCK
+++ b/lib/selenium/firefox-driver/BUCK
@@ -4,9 +4,9 @@ prebuilt_jar(
 )
 remote_file(
     name = "selenium-firefox-driver-mvn",
-    out  = "selenium-firefox-driver-3.4.0.jar",
-    url  = "mvn:org.seleniumhq.selenium:selenium-firefox-driver:jar:3.4.0",
-    sha1 = "d88e50771a0c978502dfdf770d3192c7643928eb",
+    out  = "selenium-firefox-driver-3.8.1.jar",
+    url  = "mvn:org.seleniumhq.selenium:selenium-firefox-driver:jar:3.8.1",
+    sha1 = "5df6c61edd3058b770a9bbde557f7a5ecbb584b4",
 )
 
 java_library(

--- a/web/component-test/BUCK
+++ b/web/component-test/BUCK
@@ -33,9 +33,9 @@ java_test(
         "//lib/hibernate-validator:hibernate-validator",
         '//lib/selenide:selenide',
         '//lib/selenide:selenide-dependencies',
-#         '//lib/selenium/firefox-driver:selenium-firefox-driver-with-dependencies',
+        '//lib/selenium/firefox-driver:selenium-firefox-driver-with-dependencies',
 #         '//lib/selenium/htmlunit-driver:htmlunit-driver-with-dependencies',
-        '//lib/selenium/phantomjs-driver:phantomjs-driver-with-dependencies',
+#         '//lib/selenium/phantomjs-driver:phantomjs-driver-with-dependencies',
         '//lib/spring:spring-beans',
         '//lib/spring:spring-boot-test',
         '//lib/spring:spring-context',
@@ -47,10 +47,10 @@ java_test(
         '//web/server:queue-triage-web-server',
     ],
     vm_args = [
-#         "-Dbrowser=marionette",
-#         "-Dwebdriver.gecko.driver=lib/geckodriver/geckodriver",
+        "-Dbrowser=marionette",
+        "-Dwebdriver.gecko.driver=lib/geckodriver/geckodriver",
 #         "-Dbrowser=htmlunit",
-        "-Dbrowser=phantomjs",
+#         "-Dbrowser=phantomjs",
         "-Djgiven.report.dir=buck-out/gen/web/component-test/jgiven-reports",
     ]
 )

--- a/web/component-test/BUCK
+++ b/web/component-test/BUCK
@@ -49,8 +49,6 @@ java_test(
     vm_args = [
         "-Dbrowser=firefox",
         "-Dwebdriver.gecko.driver=lib/geckodriver/geckodriver",
-#         "-Dbrowser=htmlunit",
-#         "-Dbrowser=phantomjs",
         "-Djgiven.report.dir=buck-out/gen/web/component-test/jgiven-reports",
         "-Dselenide.reports=buck-out/gen/web/component-test/selenide-output"
     ]

--- a/web/component-test/BUCK
+++ b/web/component-test/BUCK
@@ -26,6 +26,9 @@ java_library(
 
 java_test(
     name = "test",
+    labels = [
+        "component-test"
+    ],
     srcs = glob(['src/test/java/**/*Test.java']),
     deps = [
         '//common/jgiven:jgiven',

--- a/web/component-test/BUCK
+++ b/web/component-test/BUCK
@@ -52,6 +52,7 @@ java_test(
 #         "-Dbrowser=htmlunit",
 #         "-Dbrowser=phantomjs",
         "-Djgiven.report.dir=buck-out/gen/web/component-test/jgiven-reports",
+        "-Dselenide.reports=buck-out/gen/web/component-test/selenide-output"
     ]
 )
 

--- a/web/component-test/BUCK
+++ b/web/component-test/BUCK
@@ -47,7 +47,7 @@ java_test(
         '//web/server:queue-triage-web-server',
     ],
     vm_args = [
-        "-Dbrowser=marionette",
+        "-Dbrowser=firefox",
         "-Dwebdriver.gecko.driver=lib/geckodriver/geckodriver",
 #         "-Dbrowser=htmlunit",
 #         "-Dbrowser=phantomjs",

--- a/web/component-test/BUCK
+++ b/web/component-test/BUCK
@@ -51,6 +51,7 @@ java_test(
     ],
     vm_args = [
         "-Dbrowser=firefox",
+        "-Dremote=http://localhost:4444/wd/hub",
         "-Dwebdriver.gecko.driver=lib/geckodriver/geckodriver",
         "-Djgiven.report.dir=buck-out/gen/web/component-test/jgiven-reports",
         "-Dselenide.reports=buck-out/gen/web/component-test/selenide-output"

--- a/web/component-test/src/main/java/uk/gov/dwp/queue/triage/web/component/labels/LabelManagementWhenStage.java
+++ b/web/component-test/src/main/java/uk/gov/dwp/queue/triage/web/component/labels/LabelManagementWhenStage.java
@@ -15,7 +15,7 @@ public class LabelManagementWhenStage extends WhenStage<LabelManagementWhenStage
 
     public LabelManagementWhenStage theUserAddslabels$ToFailedMessage$(String labels, FailedMessageId failedMessageId) {
         LOGGER.debug("Adding label(s): {} to failedMessage: {}", labels, failedMessageId);
-        FailedMessageGrid.selectCheckboxForFailedMessage(failedMessageId, true);
+        FailedMessageGrid.selectCheckboxForFailedMessage(failedMessageId);
 
         SelenideElement cell = Selenide.$("#grid_failedMessages_rec_" + failedMessageId + " td[col='5'] div");
 
@@ -26,7 +26,7 @@ public class LabelManagementWhenStage extends WhenStage<LabelManagementWhenStage
 
         Selenide.$("#grid_failedMessages_edit_" + failedMessageId + "_5").setValue(labels);
 
-        FailedMessageGrid.selectCheckboxForFailedMessage(failedMessageId, false);
+        FailedMessageGrid.selectCheckboxForFailedMessage(failedMessageId);
         return this;
     }
 

--- a/web/component-test/src/main/java/uk/gov/dwp/queue/triage/web/component/search/SearchFailedMessageWhenStage.java
+++ b/web/component-test/src/main/java/uk/gov/dwp/queue/triage/web/component/search/SearchFailedMessageWhenStage.java
@@ -27,9 +27,8 @@ public class SearchFailedMessageWhenStage extends WhenStage<SearchFailedMessageW
                 .find(By.className("icon-search-down"))
                 .click();
         Selenide.$(By.id("w2ui-overlay-failedMessages-searchFields"))
-                .findAll("td")
-                .findBy(Condition.text("Broker"))
-                .parent()
+                .findAll(By.tagName("td"))
+                .findBy(Condition.text(fieldName))
                 .click();
         Selenide.$(By.id("grid_failedMessages_search_all"))
                 .sendKeys(searchText + Keys.RETURN);

--- a/web/component-test/src/main/java/uk/gov/dwp/queue/triage/web/component/w2ui/FailedMessageGrid.java
+++ b/web/component-test/src/main/java/uk/gov/dwp/queue/triage/web/component/w2ui/FailedMessageGrid.java
@@ -6,10 +6,9 @@ import uk.gov.dwp.queue.triage.id.FailedMessageId;
 
 public class FailedMessageGrid {
 
-    public static void selectCheckboxForFailedMessage(FailedMessageId failedMessageId, boolean selected) {
+    public static void selectCheckboxForFailedMessage(FailedMessageId failedMessageId) {
         Selenide.$(By.id("grid_failedMessages_frec_" + failedMessageId))
-                .find("input[type='checkbox']")
-                .setSelected(selected);
+                .click();
     }
 
 }


### PR DESCRIPTION
- Change the way in which certain elements on the w2ui grid are selected,
- Component tests now run separately from the rest of the "Unit Tests", the `mongo-dao` module and the `core-component-test` module tests would often overlap, leading to unpredictable behaviour.
- Firefox is run in a Docker container (this enables more predicitable/repeatable behaviour locally and on travis).

Resolves #102 
